### PR TITLE
[pull-90] Fix

### DIFF
--- a/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
+++ b/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
@@ -23,18 +23,21 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <!-- Needed by Redis to run -->
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <PackageReference Include="Docker.DotNet" Version="$(DockerVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.TestKit" Version="1.4.11" />
+    <PackageReference Include="Akka.Persistence.TCK" Version="1.4.11" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.11" />
+    <PackageReference Include="Akka.Streams.TestKit" Version="1.4.11" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
+++ b/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <PackageReference Include="Docker.DotNet" Version="$(DockerVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -34,10 +34,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="1.4.11" />
-    <PackageReference Include="Akka.Persistence.TCK" Version="1.4.11" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.11" />
-    <PackageReference Include="Akka.Streams.TestKit" Version="1.4.11" />
+    <PackageReference Include="Akka.TestKit" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisAllEventsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisAllEventsSpec.cs
@@ -8,10 +8,12 @@ using Akka.Configuration;
 using Akka.Persistence.Query;
 using Akka.Persistence.Redis.Query;
 using Akka.Persistence.TCK.Query;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Akka.Persistence.Redis.Tests.Query
 {
+    [Collection("RedisSpec")]
     public class RedisAllEventsSpec : AllEventsSpec
     {
         public const int Database = 1;
@@ -39,7 +41,7 @@ namespace Akka.Persistence.Redis.Tests.Query
             .WithFallback(RedisPersistence.DefaultConfig());
         }
 
-        public RedisAllEventsSpec(ITestOutputHelper output, RedisFixture fixture) : base(Config(fixture, Database), nameof(RedisEventsByTagSpec), output)
+        public RedisAllEventsSpec(ITestOutputHelper output, RedisFixture fixture) : base(Config(fixture, Database), nameof(RedisAllEventsSpec), output)
         {
             ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
         }

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisAllEventsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisAllEventsSpec.cs
@@ -1,0 +1,53 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisAllEventsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Tests.Query
+{
+    public class RedisAllEventsSpec : AllEventsSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                event-adapters {{
+                  color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+                }}
+                event-adapter-bindings = {{
+                  ""System.String"" = color-tagger
+                }}
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{fixture.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisAllEventsSpec(ITestOutputHelper output, RedisFixture fixture) : base(Config(fixture, Database), nameof(RedisEventsByTagSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentAllEventsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentAllEventsSpec.cs
@@ -1,0 +1,15 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisCurrentAllEventsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using Akka.Persistence.TCK.Query;
+
+namespace Akka.Persistence.Redis.Tests.Query
+{
+    public class RedisCurrentAllEventsSpec : CurrentAllEventsSpec
+    {
+    }
+}

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentAllEventsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentAllEventsSpec.cs
@@ -5,11 +5,52 @@
 //-----------------------------------------------------------------------
 
 
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
 using Akka.Persistence.TCK.Query;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.Redis.Tests.Query
 {
+    [Collection("RedisSpec")]
     public class RedisCurrentAllEventsSpec : CurrentAllEventsSpec
     {
+        public const int Database = 1;
+
+        public static Config Config(RedisFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                event-adapters {{
+                  color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+                }}
+                event-adapter-bindings = {{
+                  ""System.String"" = color-tagger
+                }}
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{fixture.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisCurrentAllEventsSpec(ITestOutputHelper output, RedisFixture fixture) : base(Config(fixture, Database), nameof(RedisCurrentAllEventsSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
@@ -61,7 +61,6 @@ namespace Akka.Persistence.Redis.Tests.Query
             //probe.Within(TimeSpan.FromSeconds(10), () => probe.Request(1).ExpectError());
         }
 
-        //now implemented
         /*[Fact(Skip = "Not implemented yet")]
         public override void ReadJournal_query_CurrentPersistenceIds_should_not_see_new_events_after_complete()
         {

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
@@ -40,11 +40,6 @@ namespace Akka.Persistence.Redis.Tests.Query
             ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
         }
 
-        [Fact(Skip = "Not implemented yet")]
-        public override void ReadJournal_query_CurrentPersistenceIds_should_not_see_new_events_after_complete()
-        {
-        }
-
         protected override void Dispose(bool disposing)
         {
             DbUtils.Clean(Database);

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Persistence.Redis.Tests.Query
         {
             ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
         }
-         
+        
         protected override void Dispose(bool disposing)
         {
             DbUtils.Clean(Database);

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
@@ -39,32 +39,7 @@ namespace Akka.Persistence.Redis.Tests.Query
         {
             ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
         }
-        [Fact]
-        public void ReadJournal_CurrentPersistenceIds_should_fail_the_stage_on_connection_error()
-        {
-            // setup redis
-            //var address = Sys.Settings.Config.GetString("akka.persistence.journal.redis.configuration-string");
-            //var database = Sys.Settings.Config.GetInt("akka.persistence.journal.redis.database");
-
-            //var redis = ConnectionMultiplexer.Connect(address).GetDatabase(database);
-
-            //var queries = ReadJournal.AsInstanceOf<ICurrentPersistenceIdsQuery>();
-
-            //Setup("a", 1);
-
-            //var source = queries.CurrentPersistenceIds();
-            //var probe = source.RunWith(this.SinkProbe<string>(), Materializer);
-
-            //// change type of value
-            //redis.StringSet("journal:persistenceIds", "1");
-
-            //probe.Within(TimeSpan.FromSeconds(10), () => probe.Request(1).ExpectError());
-        }
-
-        /*[Fact(Skip = "Not implemented yet")]
-        public override void ReadJournal_query_CurrentPersistenceIds_should_not_see_new_events_after_complete()
-        {
-        }*/
+         
         protected override void Dispose(bool disposing)
         {
             DbUtils.Clean(Database);

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisCurrentPersistenceIdsSpec.cs
@@ -39,7 +39,33 @@ namespace Akka.Persistence.Redis.Tests.Query
         {
             ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
         }
+        [Fact]
+        public void ReadJournal_CurrentPersistenceIds_should_fail_the_stage_on_connection_error()
+        {
+            // setup redis
+            //var address = Sys.Settings.Config.GetString("akka.persistence.journal.redis.configuration-string");
+            //var database = Sys.Settings.Config.GetInt("akka.persistence.journal.redis.database");
 
+            //var redis = ConnectionMultiplexer.Connect(address).GetDatabase(database);
+
+            //var queries = ReadJournal.AsInstanceOf<ICurrentPersistenceIdsQuery>();
+
+            //Setup("a", 1);
+
+            //var source = queries.CurrentPersistenceIds();
+            //var probe = source.RunWith(this.SinkProbe<string>(), Materializer);
+
+            //// change type of value
+            //redis.StringSet("journal:persistenceIds", "1");
+
+            //probe.Within(TimeSpan.FromSeconds(10), () => probe.Request(1).ExpectError());
+        }
+
+        //now implemented
+        /*[Fact(Skip = "Not implemented yet")]
+        public override void ReadJournal_query_CurrentPersistenceIds_should_not_see_new_events_after_complete()
+        {
+        }*/
         protected override void Dispose(bool disposing)
         {
             DbUtils.Clean(Database);

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisPersistenceIdsSpec.cs
@@ -46,47 +46,9 @@ namespace Akka.Persistence.Redis.Tests.Query
         {
             ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
         }
-        [Fact]
+        [Fact(Skip = "Not implemented in Redis plugin")]
         public override Task ReadJournal_should_deallocate_AllPersistenceIds_publisher_when_the_last_subscriber_left()
         {
-            if (AllocatesAllPersistenceIDsPublisher)
-            {
-                var journal = ReadJournal.AsInstanceOf<IPersistenceIdsQuery>();
-
-                Setup("a", 1);
-                Setup("b", 1);
-
-                var source = journal.PersistenceIds();
-                var probe =
-                    source.RunWith(this.SinkProbe<string>(), Materializer);
-                var probe2 =
-                    source.RunWith(this.SinkProbe<string>(), Materializer);
-
-                var fieldInfo = journal.GetType()
-                    .GetField("_persistenceIdsPublisher",
-                        BindingFlags.NonPublic | BindingFlags.Instance);
-                Assert.True(fieldInfo != null);
-
-                // Assert that publisher is running.
-                probe.Within(TimeSpan.FromSeconds(10), () => probe.Request(10)
-                    .ExpectNextUnordered("a", "b")
-                    .ExpectNoMsg(TimeSpan.FromMilliseconds(200)));
-
-                probe.Cancel();
-
-                // Assert that publisher is still alive when it still have a subscriber
-                //Assert.True(fieldInfo.GetValue(journal) is IPublisher<string>);
-
-                probe2.Within(TimeSpan.FromSeconds(10), () => probe2.Request(4)
-                    .ExpectNextUnordered("a", "b")
-                    .ExpectNoMsg(TimeSpan.FromMilliseconds(200)));
-
-                // Assert that publisher is de-allocated when the last subscriber left
-                probe2.Cancel();
-                //await Task.Delay(400);
-                //Assert.True(fieldInfo.GetValue(journal) is null);
-            }
-
             return Task.CompletedTask;
         }
 

--- a/src/Akka.Persistence.Redis.Tests/Query/RedisPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Query/RedisPersistenceIdsSpec.cs
@@ -14,6 +14,7 @@ using Akka.Persistence.TCK.Query;
 using Akka.Streams.TestKit;
 using Akka.Util.Internal;
 using Reactive.Streams;
+using StackExchange.Redis;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -89,26 +90,26 @@ namespace Akka.Persistence.Redis.Tests.Query
             return Task.CompletedTask;
         }
 
-        [Fact(Skip = "Not implemented yet")]
+        [Fact]
         public void ReadJournal_AllPersistenceIds_should_fail_the_stage_on_connection_error()
         {
             // setup redis
-            //var address = Sys.Settings.Config.GetString("akka.persistence.journal.redis.configuration-string");
-            //var database = Sys.Settings.Config.GetInt("akka.persistence.journal.redis.database");
+            var address = Sys.Settings.Config.GetString("akka.persistence.journal.redis.configuration-string");
+            var database = Sys.Settings.Config.GetInt("akka.persistence.journal.redis.database");
 
-            //var redis = ConnectionMultiplexer.Connect(address).GetDatabase(database);
+            var redis = ConnectionMultiplexer.Connect(address).GetDatabase(database);
 
-            //var queries = ReadJournal.AsInstanceOf<IAllPersistenceIdsQuery>();
+            var queries = ReadJournal.AsInstanceOf<IPersistenceIdsQuery>();
 
-            //Setup("a", 1);
+            Setup("a", 1);
 
-            //var source = queries.AllPersistenceIds();
-            //var probe = source.RunWith(this.SinkProbe<string>(), Materializer);
+            var source = queries.PersistenceIds();
+            var probe = source.RunWith(this.SinkProbe<string>(), Materializer);
 
             //// change type of value
-            //redis.StringSet("journal:persistenceIds", "1");
+            redis.StringSet("journal:persistenceIds", "1");
 
-            //probe.Within(TimeSpan.FromSeconds(10), () => probe.Request(1).ExpectError());
+            probe.Within(TimeSpan.FromSeconds(10), () => probe.Request(1).ExpectError());
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalPerfSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Persistence.Redis.Tests
         public RedisJournalPerfSpec(ITestOutputHelper output, RedisFixture fixture) : base(Config(fixture, Database), nameof(RedisJournalPerfSpec), output)
         {
             EventsCount = 1000;
-            ExpectDuration = TimeSpan.FromMinutes(10);
+            ExpectDuration = TimeSpan.FromMinutes(2);
             MeasurementIterations = 1;
         }
 

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalPerfSpec.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Configuration;
 using Akka.Persistence.Redis.Query;
 using Akka.Persistence.TestKit.Performance;
@@ -37,6 +38,9 @@ namespace Akka.Persistence.Redis.Tests
 
         public RedisJournalPerfSpec(ITestOutputHelper output, RedisFixture fixture) : base(Config(fixture, Database), nameof(RedisJournalPerfSpec), output)
         {
+            EventsCount = 1000;
+            ExpectDuration = TimeSpan.FromMinutes(10);
+            MeasurementIterations = 1;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalPerfSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Persistence.Redis.Tests
         public RedisJournalPerfSpec(ITestOutputHelper output, RedisFixture fixture) : base(Config(fixture, Database), nameof(RedisJournalPerfSpec), output)
         {
             EventsCount = 1000;
-            ExpectDuration = TimeSpan.FromMinutes(5);
+            ExpectDuration = TimeSpan.FromMinutes(10);
             MeasurementIterations = 1;
         }
 

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalPerfSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Persistence.Redis.Tests
         public RedisJournalPerfSpec(ITestOutputHelper output, RedisFixture fixture) : base(Config(fixture, Database), nameof(RedisJournalPerfSpec), output)
         {
             EventsCount = 1000;
-            ExpectDuration = TimeSpan.FromMinutes(2);
+            ExpectDuration = TimeSpan.FromMinutes(5);
             MeasurementIterations = 1;
         }
 

--- a/src/Akka.Persistence.Redis/Akka.Persistence.Redis.csproj
+++ b/src/Akka.Persistence.Redis/Akka.Persistence.Redis.csproj
@@ -15,13 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.11" />
+    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
     <PackageReference Include="Akka.Persistence" Version="$(AkkaVersion)" />
     <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Streams" Version="1.4.11" />
+    <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
     <PackageReference Include="StackExchange.Redis" Version="$(RedisVersion)" />
-    <PackageReference Include="Akka.Persistence" Version="1.4.11" />
-    <PackageReference Include="Akka.Persistence.Query" Version="1.4.11" />
-    <PackageReference Include="StackExchange.Redis" Version="$(RedisVersion)" />
+    <PackageReference Include="Akka.Persistence" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.Redis/Akka.Persistence.Redis.csproj
+++ b/src/Akka.Persistence.Redis/Akka.Persistence.Redis.csproj
@@ -15,13 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka" Version="1.4.11" />
     <PackageReference Include="Akka.Persistence" Version="$(AkkaVersion)" />
     <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Streams" Version="1.4.11" />
     <PackageReference Include="StackExchange.Redis" Version="$(RedisVersion)" />
-    <PackageReference Include="Akka.Persistence" Version="$(AkkaVersion)" />
-    <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Persistence" Version="1.4.11" />
+    <PackageReference Include="Akka.Persistence.Query" Version="1.4.11" />
     <PackageReference Include="StackExchange.Redis" Version="$(RedisVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
+++ b/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
@@ -100,6 +100,13 @@ namespace Akka.Persistence.Redis.Journal
                 // notify about a new event being appended for this persistence id
                 transaction.PublishAsync(_journalHelper.GetJournalChannel(payload.PersistenceId), payload.SequenceNr);
 
+                //save event
+                var evt = $"{payload.SequenceNr}:{payload.PersistenceId}";
+                transaction.ListRightPushAsync(_journalHelper.GetEventsKey(), evt);
+
+                // notify about this event
+                transaction.PublishAsync(_journalHelper.GetEventsChannel(), evt);
+
                 // save tags
                 foreach (var tag in tags)
                 {

--- a/src/Akka.Persistence.Redis/JournalHelper.cs
+++ b/src/Akka.Persistence.Redis/JournalHelper.cs
@@ -39,5 +39,7 @@ namespace Akka.Persistence.Redis
         public string GetTagKey(string tag) => $"{KeyPrefix}journal:tag:{tag}";
         public string GetTagsChannel() => $"{KeyPrefix}journal:channel:tags";
         public string GetIdentifiersChannel() => $"{KeyPrefix}journal:channel:ids";
+
+        public string GetJournalChannel() => $"{KeyPrefix}journal:channel:persisted:";
     }
 }

--- a/src/Akka.Persistence.Redis/JournalHelper.cs
+++ b/src/Akka.Persistence.Redis/JournalHelper.cs
@@ -38,8 +38,9 @@ namespace Akka.Persistence.Redis
         public string GetJournalChannel(string persistenceId) => $"{KeyPrefix}journal:channel:persisted:{persistenceId}";
         public string GetTagKey(string tag) => $"{KeyPrefix}journal:tag:{tag}";
         public string GetTagsChannel() => $"{KeyPrefix}journal:channel:tags";
+        public string GetEventsChannel() => $"{KeyPrefix}journal:channel:events";
+        public string GetEventsKey() => $"{KeyPrefix}journal:events";
         public string GetIdentifiersChannel() => $"{KeyPrefix}journal:channel:ids";
 
-        public string GetJournalChannel() => $"{KeyPrefix}journal:channel:persisted:";
     }
 }

--- a/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
+++ b/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
@@ -200,7 +200,7 @@ namespace Akka.Persistence.Redis.Query
         public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset)
         {
             offset = offset ?? new Sequence(0L);
-            switch (offset)
+            switch (offset) 
             {
                 case Sequence seq:
                     return Source.FromGraph(new AllEventsSource(_redis, _database, _config, seq.Value, _system, false));

--- a/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
+++ b/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
@@ -149,6 +149,36 @@ namespace Akka.Persistence.Redis.Query
             }
         }
 
+        /// <summary>
+        /// <see cref="AllEvents"/> is used for retrieving all events
+        /// <para></para>
+        /// You can use <see cref="NoOffset"/> to retrieve all events or retrieve a subset of all
+        /// events by specifying a <see cref="Sequence"/>. The `offset` corresponds to an ordered sequence number 
+        /// Note that the corresponding offset of each event is provided in the
+        /// <see cref="EventEnvelope"/>, which makes it possible to resume the
+        /// stream at a later point from a given offset.
+        /// <para></para>
+        /// The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+        /// in the returned stream.This means that you can use the offset that is returned in <see cref="EventEnvelope"/>
+        /// as the `offset` parameter in a subsequent query.
+        /// <para></para>
+        /// In addition to the <paramref name="offset"/> the <see cref="EventEnvelope"/> also provides `persistenceId` and `sequenceNr`
+        /// for each event. The `sequenceNr` is the sequence number for the persistent actor with the
+        /// `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
+        /// identifier for the event.
+        /// <para></para>
+        /// The stream is not completed when it reaches the end of the currently stored events,
+        /// but it continues to push new events when new events are persisted.
+        /// Corresponding query that is completed when it reaches the end of the currently
+        /// stored events is provided by <see cref="CurrentAllEvents"/>.
+        /// <para></para>
+        /// The MongoDB write journal is notifying the query side as soon as events are persisted, but for
+        /// efficiency reasons the query side retrieves the events in batches that sometimes can
+        /// be delayed up to the configured `refresh-interval`.
+        /// <para></para>
+        /// The stream is completed with failure if there is a failure in executing the query in the
+        /// backend journal.
+        /// </summary>
         public Source<EventEnvelope, NotUsed> AllEvents(Offset offset = null)
         {
             offset = offset ?? new Sequence(0L);
@@ -162,7 +192,11 @@ namespace Akka.Persistence.Redis.Query
                     throw new ArgumentException($"RedisReadJournal does not support {offset.GetType().Name} offsets");
             }
         }
-
+        /// <summary>
+        /// Same type of query as <see cref="AllEvents"/> but the event stream
+        /// is completed immediately when it reaches the end of the "result set". Events that are
+        /// stored after the query is completed are not included in the event stream.
+        /// </summary>
         public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset)
         {
             offset = offset ?? new Sequence(0L);

--- a/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
+++ b/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
@@ -16,13 +16,14 @@ using Akka.Streams;
 namespace Akka.Persistence.Redis.Query
 {
     public class RedisReadJournal :
-        IReadJournal,
         IPersistenceIdsQuery,
         ICurrentPersistenceIdsQuery,
         IEventsByPersistenceIdQuery,
         ICurrentEventsByPersistenceIdQuery,
+        IEventsByTagQuery,
         ICurrentEventsByTagQuery,
-        IEventsByTagQuery
+        IAllEventsQuery,
+        ICurrentAllEventsQuery
     {
         private readonly ExtendedActorSystem _system;
         private readonly Config _config;
@@ -112,6 +113,16 @@ namespace Akka.Persistence.Redis.Query
                 default:
                     throw new ArgumentException($"RedisReadJournal does not support {offset.GetType().Name} offsets");
             }
+        }
+
+        public Source<EventEnvelope, NotUsed> AllEvents(Offset offset)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
+++ b/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
@@ -157,7 +157,7 @@ namespace Akka.Persistence.Redis.Query
         /// Corresponding query that is completed when it reaches the end of the currently
         /// stored events is provided by <see cref="CurrentAllEvents"/>.
         /// <para></para>
-        /// The MongoDB write journal is notifying the query side as soon as events are persisted, but for
+        /// The Redis write journal is notifying the query side as soon as events are persisted, but for
         /// efficiency reasons the query side retrieves the events in batches that sometimes can
         /// be delayed up to the configured `refresh-interval`.
         /// <para></para>
@@ -177,10 +177,33 @@ namespace Akka.Persistence.Redis.Query
                     throw new ArgumentException($"RedisReadJournal does not support {offset.GetType().Name} offsets");
             }
         }
+
         /// <summary>
-        /// Same type of query as <see cref="AllEvents"/> but the event stream
+        /// <see cref="CurrentAllEvents"/> is used for retrieving all stored events, the event stream
         /// is completed immediately when it reaches the end of the "result set". Events that are
-        /// stored after the query is completed are not included in the event stream.
+        /// stored after the query is completed are not included in the event stream
+        /// <para></para>
+        /// You can use <see cref="NoOffset"/> to retrieve all stored events or retrieve a subset of all stored
+        /// events by specifying a <see cref="Sequence"/>. The `offset` corresponds to an ordered sequence number 
+        /// Note that the corresponding offset of each event is provided in the
+        /// <see cref="EventEnvelope"/>, which makes it possible to resume the
+        /// stream at a later point from a given offset.
+        /// <para></para>
+        /// The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+        /// in the returned stream.This means that you can use the offset that is returned in <see cref="EventEnvelope"/>
+        /// as the `offset` parameter in a subsequent query.
+        /// <para></para>
+        /// In addition to the <paramref name="offset"/> the <see cref="EventEnvelope"/> also provides `persistenceId` and `sequenceNr`
+        /// for each event. The `sequenceNr` is the sequence number for the persistent actor with the
+        /// `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
+        /// identifier for the event.        
+        /// <para></para>
+        /// The Redis write journal is notifying the query side as soon as events are persisted, but for
+        /// efficiency reasons the query side retrieves the events in batches that sometimes can
+        /// be delayed up to the configured `refresh-interval`.
+        /// <para></para>
+        /// The stream is completed with failure if there is a failure in executing the query in the
+        /// backend journal.
         /// </summary>
         public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset)
         {

--- a/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
+++ b/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
@@ -1,0 +1,348 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Pattern;
+using Akka.Persistence.Query;
+using Akka.Streams;
+using Akka.Streams.Stage;
+using StackExchange.Redis;
+
+namespace Akka.Persistence.Redis.Query.Stages
+{
+    internal class AllEventsSource : GraphStage<SourceShape<EventEnvelope>>
+    {
+        private readonly ConnectionMultiplexer _redis;
+        private readonly int _database;
+        private readonly Config _config;
+        private readonly long _fromSequenceNr;
+        private readonly long _toSequenceNr;
+        private readonly ActorSystem _system;
+        private readonly bool _live;
+
+        public AllEventsSource(ConnectionMultiplexer redis, int database, Config config, long fromSequenceNr, long toSequenceNr, ActorSystem system, bool live)
+        {
+            _redis = redis;
+            _database = database;
+            _config = config;
+            _fromSequenceNr = fromSequenceNr;
+            _toSequenceNr = toSequenceNr;
+            _system = system;
+            _live = live;
+
+            Outlet = live
+                ? new Outlet<EventEnvelope>("AllEventsSource")
+                : new Outlet<EventEnvelope>("AllCurrentEventsSource");
+
+            Shape = new SourceShape<EventEnvelope>(Outlet);
+        }
+
+        internal Outlet<EventEnvelope> Outlet { get; }
+
+        public override SourceShape<EventEnvelope> Shape { get; }
+
+        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+        {
+            return new AllEventsLogic(_redis, _database, _config, _system, _fromSequenceNr, _toSequenceNr, _live, Outlet, Shape);
+        }
+
+        private enum State
+        {
+            Idle = 0,
+            Querying = 1,
+            NotifiedWhenQuerying = 2,
+            WaitingForNotification = 3,
+            Initializing = 4,
+            QueryWhenInitializing = 5
+        }
+
+        private class AllEventsLogic : GraphStageLogic
+        {
+            private State _state = State.Idle;
+            private readonly Queue<EventEnvelope> _buffer = new Queue<EventEnvelope>();
+            private ISubscriber _subscription;
+            private readonly int _max;
+            private readonly JournalHelper _journalHelper;
+            private long _currentSequenceNr;
+            private Action<IReadOnlyList<IPersistentRepresentation>> _callback;
+
+            private readonly Outlet<EventEnvelope> _outlet;
+            private readonly ConnectionMultiplexer _redis;
+            private readonly int _database;
+            private readonly ActorSystem _system;
+            private long _toSequenceNr;
+            private readonly bool _live;
+
+            public AllEventsLogic(
+                ConnectionMultiplexer redis,
+                int database,
+                Config config,
+                ActorSystem system,
+                long fromSequenceNr,
+                long toSequenceNr,
+                bool live,
+                Outlet<EventEnvelope> outlet, Shape shape) : base(shape)
+            {
+                _outlet = outlet;
+                _redis = redis;
+                _database = database;
+                _system = system;
+                _toSequenceNr = toSequenceNr;
+                _live = live;
+
+                _max = config.GetInt("max-buffer-size");
+                _journalHelper = new JournalHelper(system, system.Settings.Config.GetString("akka.persistence.journal.redis.key-prefix"));
+
+                _currentSequenceNr = fromSequenceNr;
+                SetHandler(outlet, onPull: () =>
+                {
+                    switch (_state)
+                    {
+                        case State.Initializing:
+                            _state = State.QueryWhenInitializing;
+                            break;
+                        default:
+                            Query();
+                            break;
+                    }
+                });
+            }
+
+            public override void PreStart()
+            {
+                _callback = GetAsyncCallback<IReadOnlyList<IPersistentRepresentation>>(events =>
+                {
+                    if (events.Count == 0)
+                    {
+                        if (_currentSequenceNr > _toSequenceNr)
+                        {
+                            // end has been reached
+                            CompleteStage();
+                        }
+                        else
+                        {
+                            switch (_state)
+                            {
+                                case State.NotifiedWhenQuerying:
+                                    // maybe we missed some new event when querying, retry
+                                    _state = State.Idle;
+                                    Query();
+                                    break;
+                                case State.Querying:
+                                    if (_live)
+                                    {
+                                        // nothing new, wait for notification
+                                        _state = State.WaitingForNotification;
+                                    }
+                                    else
+                                    {
+                                        // not a live stream, nothing else currently in the database, close the stream
+                                        CompleteStage();
+                                    }
+                                    break;
+                                default:
+                                    Log.Error($"Unexpected source state: {_state}");
+                                    FailStage(new IllegalStateException($"Unexpected source state: {_state}"));
+                                    break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var (evts, maxSequenceNr) = events.Aggregate((new List<EventEnvelope>(), _currentSequenceNr), (tuple, pr) =>
+                        {
+                            if (!pr.IsDeleted &&
+                                pr.SequenceNr >= _currentSequenceNr &&
+                                pr.SequenceNr <= _toSequenceNr)
+                            {
+                                tuple.Item1.Add(new EventEnvelope(new Sequence(pr.SequenceNr), pr.PersistenceId, pr.SequenceNr, pr.Payload));
+                                tuple.Item2 = pr.SequenceNr + 1;
+                            }
+                            else
+                            {
+                                tuple.Item2 = pr.SequenceNr + 1;
+                            }
+
+                            return tuple;
+                        });
+
+                        _currentSequenceNr = maxSequenceNr;
+                        Log.Debug($"Max sequence number is now {maxSequenceNr}");
+                        if (evts.Count > 0)
+                        {
+                            evts.ForEach(_buffer.Enqueue);
+                            Deliver();
+                        }
+                        else
+                        {
+                            // requery immediately
+                            _state = State.Idle;
+                            Query();
+                        }
+                    }
+                });
+
+                if (_live)
+                {
+                    // subscribe to notification stream only if live stream was required
+                    var messageCallback = GetAsyncCallback<(RedisChannel channel, string bs)>(data =>
+                    {
+                        if (data.channel.ToString().StartsWith(_journalHelper.GetJournalChannel()))
+                        {
+                            Log.Debug("Message received");
+
+                            switch (_state)
+                            {
+                                case State.Idle:
+                                    // do nothing, no query is running and no client request was performed
+                                    break;
+                                case State.Querying:
+                                    _state = State.NotifiedWhenQuerying;
+                                    break;
+                                case State.NotifiedWhenQuerying:
+                                    // do nothing we already know that some new events may exist
+                                    break;
+                                case State.WaitingForNotification:
+                                    _state = State.Idle;
+                                    Query();
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            Log.Debug($"Message from unexpected channel: {data.channel}");
+                        }
+                    });
+
+                    _subscription = _redis.GetSubscriber();
+                    _subscription.Subscribe(_journalHelper.GetJournalChannel("*"), (channel, value) =>
+                    {
+                        messageCallback.Invoke((channel, value));
+                    });
+                }
+                else
+                {
+                    // start by first querying the current highest sequenceNr
+                    // for the given persistent id
+                    // stream will stop once this has been delivered
+                    _state = State.Initializing;
+
+                    var initCallback = GetAsyncCallback<long>(sn =>
+                    {
+                        if (_toSequenceNr > sn)
+                        {
+                            // the initially requested max sequence number is higher than the current
+                            // one, restrict it to the current one
+                            _toSequenceNr = sn;
+                        }
+
+                        switch (_state)
+                        {
+                            case State.QueryWhenInitializing:
+                                // during initialization, downstream asked for an element,
+                                // let’s query elements
+                                _state = State.Idle;
+                                Query();
+                                break;
+                            case State.Initializing:
+                                // no request from downstream, just go idle
+                                _state = State.Idle;
+                                break;
+                            default:
+                                Log.Error($"Unexpected source state when initializing: {_state}");
+                                FailStage(new IllegalStateException($"Unexpected source state when initializing: {_state}"));
+                                break;
+                        }
+                    });
+
+                    _redis.GetDatabase(_database).StringGetAsync(_journalHelper.GetHighestSequenceNrKey(_persistenceId)).ContinueWith(task =>
+                    {
+                        if (!task.IsCanceled || task.IsFaulted)
+                        {
+                            if (task.Result.IsNull == true)
+                            {
+                                // not found, close
+                                CompleteStage();
+                            }
+                            else
+                            {
+                                initCallback(long.Parse(task.Result));
+                            }
+                        }
+                        else
+                        {
+                            Log.Error(task.Exception, "Error while initializing current events by persistent id");
+                            FailStage(task.Exception);
+                        }
+                    });
+                }
+            }
+
+            public override void PostStop()
+            {
+                _subscription?.UnsubscribeAll();
+            }
+
+            private void Query()
+            {
+                switch (_state)
+                {
+                    case State.Idle:
+                        if (_buffer.Count == 0)
+                        {
+                            // so, we need to fill this buffer
+                            _state = State.Querying;
+
+                            // Complete stage if fromSequenceNr is higher than toSequenceNr
+                            if (_toSequenceNr < _currentSequenceNr)
+                            {
+                                CompleteStage();
+                            }
+
+                            _redis.GetDatabase(_database).SortedSetRangeByScoreAsync(
+                                key: _journalHelper.GetJournalKey(_persistenceId),
+                                start: _currentSequenceNr,
+                                stop: Math.Min(_currentSequenceNr + _max - 1, _toSequenceNr),
+                                order: Order.Ascending).ContinueWith(task =>
+                                {
+                                    if (!task.IsCanceled || task.IsFaulted)
+                                    {
+                                        var deserializedEvents = task.Result.Select(e => _journalHelper.PersistentFromBytes(e)).ToList();
+                                        _callback(deserializedEvents);
+                                    }
+                                    else
+                                    {
+                                        Log.Error(task.Exception, "Error while querying events by persistence identifier");
+                                        FailStage(task.Exception);
+                                    }
+                                });
+                        }
+                        else
+                        {
+                            // buffer is non empty, let’s deliver buffered data
+                            Deliver();
+                        }
+                        break;
+                    default:
+                        Log.Error($"Unexpected source state when querying: {_state}");
+                        FailStage(new IllegalStateException($"Unexpected source state when querying: {_state}"));
+                        break;
+                }
+            }
+
+            private void Deliver()
+            {
+                // go back to idle state, waiting for more client request
+                _state = State.Idle;
+                var elem = _buffer.Dequeue();
+                Push(_outlet, elem);
+                if (_buffer.Count == 0 && _currentSequenceNr > _toSequenceNr)
+                {
+                    // we delivered last buffered event and the upper bound was reached, complete
+                    CompleteStage();
+                }
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
+++ b/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
@@ -212,10 +212,6 @@ namespace Akka.Persistence.Redis.Query.Stages
                                     break;
                             }
                         }
-                        else if (data.channel.Equals(_journalHelper.GetEventsChannel()))
-                        {
-                            // ignore other tags
-                        }
                         else
                         {
                             Log.Debug($"Message from unexpected channel: {data.channel}");

--- a/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
+++ b/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
@@ -17,7 +17,6 @@ using StackExchange.Redis;
 
 namespace Akka.Persistence.Redis.Query.Stages
 {
-    //https://dzone.com/articles/tips-amp-tricks-to-using-keys-innbspredis
     internal class AllEventsSource : GraphStage<SourceShape<EventEnvelope>>
     {
         private readonly ConnectionMultiplexer _redis;
@@ -169,7 +168,8 @@ namespace Akka.Persistence.Redis.Query.Stages
                             }
 
                             return null;
-                        }).ToList();
+                        })//in case of null
+                        .Where(x=> x != null).ToList();
 
                         _currentOffset += nb;
                         if (evts.Count > 0)

--- a/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
+++ b/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
@@ -11,6 +11,7 @@ using StackExchange.Redis;
 
 namespace Akka.Persistence.Redis.Query.Stages
 {
+    //https://dzone.com/articles/tips-amp-tricks-to-using-keys-innbspredis
     internal class AllEventsSource : GraphStage<SourceShape<EventEnvelope>>
     {
         private readonly ConnectionMultiplexer _redis;
@@ -74,15 +75,7 @@ namespace Akka.Persistence.Redis.Query.Stages
             private long _toSequenceNr;
             private readonly bool _live;
 
-            public AllEventsLogic(
-                ConnectionMultiplexer redis,
-                int database,
-                Config config,
-                ActorSystem system,
-                long fromSequenceNr,
-                long toSequenceNr,
-                bool live,
-                Outlet<EventEnvelope> outlet, Shape shape) : base(shape)
+            public AllEventsLogic(ConnectionMultiplexer redis, int database, Config config, ActorSystem system, long fromSequenceNr, long toSequenceNr, bool live, Outlet<EventEnvelope> outlet, Shape shape) : base(shape)
             {
                 _outlet = outlet;
                 _redis = redis;
@@ -152,9 +145,7 @@ namespace Akka.Persistence.Redis.Query.Stages
                     {
                         var (evts, maxSequenceNr) = events.Aggregate((new List<EventEnvelope>(), _currentSequenceNr), (tuple, pr) =>
                         {
-                            if (!pr.IsDeleted &&
-                                pr.SequenceNr >= _currentSequenceNr &&
-                                pr.SequenceNr <= _toSequenceNr)
+                            if (!pr.IsDeleted && pr.SequenceNr >= _currentSequenceNr && pr.SequenceNr <= _toSequenceNr)
                             {
                                 tuple.Item1.Add(new EventEnvelope(new Sequence(pr.SequenceNr), pr.PersistenceId, pr.SequenceNr, pr.Payload));
                                 tuple.Item2 = pr.SequenceNr + 1;

--- a/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
+++ b/src/Akka.Persistence.Redis/Query/Stages/AllEventsSource.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="EventsByTagSource.cs" company="Akka.NET Project">
+// <copyright file="AllEventsSource.cs" company="Akka.NET Project">
 //     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
 // </copyright>
 //-----------------------------------------------------------------------

--- a/src/Akka.Persistence.Redis/Query/Stages/EventsByTagSource.cs
+++ b/src/Akka.Persistence.Redis/Query/Stages/EventsByTagSource.cs
@@ -298,10 +298,7 @@ namespace Akka.Persistence.Redis.Query.Stages
                             _state = State.Querying;
 
                             // request next batch of events for this tag (potentially limiting to the max offset in the case of non live stream)
-                            var refs = _redis.GetDatabase(_database).ListRange(
-                                _journalHelper.GetTagKey(_tag),
-                                _currentOffset,
-                                Math.Min(_maxOffset, _currentOffset + _max - 1));
+                            var refs = _redis.GetDatabase(_database).ListRange(_journalHelper.GetTagKey(_tag), _currentOffset, Math.Min(_maxOffset, _currentOffset + _max - 1));
 
                             var trans = _redis.GetDatabase(_database).CreateTransaction();
 

--- a/src/Akka.Persistence.Redis/Query/Stages/PersistenceIdsSource.cs
+++ b/src/Akka.Persistence.Redis/Query/Stages/PersistenceIdsSource.cs
@@ -26,6 +26,7 @@ namespace Akka.Persistence.Redis.Query.Stages
             _redis = redis;
             _database = database;
             _system = system;
+            
         }
 
         public Outlet<string> Outlet { get; } = new Outlet<string>(nameof(PersistenceIdsSource));
@@ -49,6 +50,7 @@ namespace Akka.Persistence.Redis.Query.Stages
             private readonly ConnectionMultiplexer _redis;
             private readonly int _database;
             private readonly JournalHelper _journalHelper;
+           
 
             public PersistenceIdsLogic(ConnectionMultiplexer redis, int database, ExtendedActorSystem system, Outlet<string> outlet, Shape shape) : base(shape)
             {
@@ -56,7 +58,6 @@ namespace Akka.Persistence.Redis.Query.Stages
                 _database = database;
                 _journalHelper = new JournalHelper(system, system.Settings.Config.GetString("akka.persistence.journal.redis.key-prefix"));
                 _outlet = outlet;
-
                 SetHandler(outlet, onPull: () =>
                 {
                     _downstreamWaiting = true;

--- a/src/common.props
+++ b/src/common.props
@@ -17,7 +17,7 @@
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.8.0</TestSdkVersion>
     <AkkaVersion>1.4.12</AkkaVersion>
-    <RedisVersion>2.1.58</RedisVersion>
+    <RedisVersion>2.2.4</RedisVersion>
     <DockerVersion>3.125.4</DockerVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.8.0</TestSdkVersion>
-    <AkkaVersion>1.4.9</AkkaVersion>
+    <AkkaVersion>1.4.12</AkkaVersion>
     <RedisVersion>2.1.58</RedisVersion>
     <DockerVersion>3.125.4</DockerVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.8.0</TestSdkVersion>
-    <AkkaVersion>1.4.12</AkkaVersion>
+    <AkkaVersion>1.4.13</AkkaVersion>
     <RedisVersion>2.2.4</RedisVersion>
     <DockerVersion>3.125.4</DockerVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.7.1</TestSdkVersion>
+    <TestSdkVersion>16.8.0</TestSdkVersion>
     <AkkaVersion>1.4.9</AkkaVersion>
     <RedisVersion>2.1.58</RedisVersion>
     <DockerVersion>3.125.4</DockerVersion>

--- a/src/examples/CustomSerialization.MsgPack/CustomSerialization.MsgPack.csproj
+++ b/src/examples/CustomSerialization.MsgPack/CustomSerialization.MsgPack.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="1.9.11" />
+    <PackageReference Include="MessagePack" Version="2.2.60" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">

--- a/src/examples/CustomSerialization.MsgPack/Program.cs
+++ b/src/examples/CustomSerialization.MsgPack/Program.cs
@@ -15,7 +15,7 @@ using Akka.Pattern;
 
 namespace CustomSerialization.MsgPack
 {
-    //docker run --name test-redis-container -p 6379:6379 -d redis
+    
     class Program
     {
         // if you want to benchmark your persistent storage provides, paste the configuration in string below

--- a/src/examples/CustomSerialization.MsgPack/Program.cs
+++ b/src/examples/CustomSerialization.MsgPack/Program.cs
@@ -15,6 +15,7 @@ using Akka.Pattern;
 
 namespace CustomSerialization.MsgPack
 {
+    //docker run --name test-redis-container -p 6379:6379 -d redis
     class Program
     {
         // if you want to benchmark your persistent storage provides, paste the configuration in string below

--- a/src/examples/CustomSerialization.MsgPack/Serialization/ActorPathResolver.cs
+++ b/src/examples/CustomSerialization.MsgPack/Serialization/ActorPathResolver.cs
@@ -40,7 +40,7 @@ namespace CustomSerialization.MsgPack.Serialization
 
     public class ActorPathFormatter<T> : IMessagePackFormatter<T> where T : ActorPath
     {
-        public int Serialize(ref byte[] bytes, int offset, T value, IFormatterResolver formatterResolver)
+        /**public int Serialize(ref byte[] bytes, int offset, T value, IFormatterResolver formatterResolver)
         {
             if (value == null)
             {
@@ -61,6 +61,26 @@ namespace CustomSerialization.MsgPack.Serialization
             }
 
             var path = MessagePackBinary.ReadString(bytes, offset, out readSize);
+            return ActorPath.TryParse(path, out var actorPath) ? (T)actorPath : null;
+        }
+        */
+        public void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+            }
+            writer.Write(value.ToSerializationFormat());
+        }
+
+        public T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            if (reader.IsNil)
+            {
+                return null;
+            }
+
+            var path = reader.ReadString();
             return ActorPath.TryParse(path, out var actorPath) ? (T)actorPath : null;
         }
     }

--- a/src/examples/CustomSerialization.MsgPack/Serialization/ActorPathResolver.cs
+++ b/src/examples/CustomSerialization.MsgPack/Serialization/ActorPathResolver.cs
@@ -40,35 +40,14 @@ namespace CustomSerialization.MsgPack.Serialization
 
     public class ActorPathFormatter<T> : IMessagePackFormatter<T> where T : ActorPath
     {
-        /**public int Serialize(ref byte[] bytes, int offset, T value, IFormatterResolver formatterResolver)
-        {
-            if (value == null)
-            {
-                return MessagePackBinary.WriteNil(ref bytes, offset);
-            }
-
-            var startOffset = offset;
-            offset += MessagePackBinary.WriteString(ref bytes, offset, value.ToSerializationFormat());
-            return offset - startOffset;
-        }
-
-        public T Deserialize(byte[] bytes, int offset, IFormatterResolver formatterResolver, out int readSize)
-        {
-            if (MessagePackBinary.IsNil(bytes, offset))
-            {
-                readSize = 1;
-                return null;
-            }
-
-            var path = MessagePackBinary.ReadString(bytes, offset, out readSize);
-            return ActorPath.TryParse(path, out var actorPath) ? (T)actorPath : null;
-        }
-        */
+        
         public void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options)
         {
             if (value == null)
             {
                 writer.WriteNil();
+
+                return;
             }
             writer.Write(value.ToSerializationFormat());
         }

--- a/src/examples/CustomSerialization.MsgPack/Serialization/MsgPackSerializer.cs
+++ b/src/examples/CustomSerialization.MsgPack/Serialization/MsgPackSerializer.cs
@@ -54,10 +54,11 @@ namespace CustomSerialization.MsgPack.Serialization
 
         static MsgPackSerializer()
         {
-            CompositeResolver.RegisterAndSetAsDefault(
+            /*CompositeResolver.RegisterAndSetAsDefault(
                 ActorPathResolver.Instance,
                 OldSpecResolver.Instance, // Redis compatible MsgPack spec
-                ContractlessStandardResolver.Instance);
+                ContractlessStandardResolver.Instance);*/
+            CompositeResolver.Create(new[] { ActorPathResolver.Instance }/*, new[] { ContractlessStandardResolver.Instance }*/);
         }
 
         public MsgPackSerializer(ExtendedActorSystem system) : base(system)
@@ -69,7 +70,7 @@ namespace CustomSerialization.MsgPack.Serialization
             if (obj is IPersistentRepresentation repr)
                 return PersistenceMessageSerializer(repr);
 
-            return MessagePackSerializer.NonGeneric.Serialize(obj.GetType(), obj);
+            return MessagePackSerializer.Serialize(obj.GetType(), obj);
         }
 
         public override object FromBinary(byte[] bytes, Type type)
@@ -77,7 +78,7 @@ namespace CustomSerialization.MsgPack.Serialization
             if (typeof(IPersistentRepresentation).IsAssignableFrom(type))
                 return PersistenceMessageDeserializer(bytes);
 
-            return MessagePackSerializer.NonGeneric.Deserialize(type, bytes);
+            return MessagePackSerializer.Deserialize(type, bytes);
         }
 
         public override int Identifier => 30;

--- a/src/examples/CustomSerialization.MsgPack/Serialization/MsgPackSerializer.cs
+++ b/src/examples/CustomSerialization.MsgPack/Serialization/MsgPackSerializer.cs
@@ -54,11 +54,7 @@ namespace CustomSerialization.MsgPack.Serialization
 
         static MsgPackSerializer()
         {
-            /*CompositeResolver.RegisterAndSetAsDefault(
-                ActorPathResolver.Instance,
-                OldSpecResolver.Instance, // Redis compatible MsgPack spec
-                ContractlessStandardResolver.Instance);*/
-            CompositeResolver.Create(new[] { ActorPathResolver.Instance }/*, new[] { ContractlessStandardResolver.Instance }*/);
+            CompositeResolver.Create(new[] { ActorPathResolver.Instance });
         }
 
         public MsgPackSerializer(ExtendedActorSystem system) : base(system)

--- a/src/examples/CustomSerialization.Protobuf/Program.cs
+++ b/src/examples/CustomSerialization.Protobuf/Program.cs
@@ -15,7 +15,7 @@ using Akka.Pattern;
 
 namespace CustomSerialization.Protobuf
 {
-    //docker run --name test-redis-container -p 6379:6379 -d redis
+    
     class Program
     {
         // if you want to benchmark your persistent storage provides, paste the configuration in string below

--- a/src/examples/CustomSerialization.Protobuf/Program.cs
+++ b/src/examples/CustomSerialization.Protobuf/Program.cs
@@ -15,6 +15,7 @@ using Akka.Pattern;
 
 namespace CustomSerialization.Protobuf
 {
+    //docker run --name test-redis-container -p 6379:6379 -d redis
     class Program
     {
         // if you want to benchmark your persistent storage provides, paste the configuration in string below

--- a/src/examples/CustomSerialization.Protobuf/Serialization/ProtobufSerializer.cs
+++ b/src/examples/CustomSerialization.Protobuf/Serialization/ProtobufSerializer.cs
@@ -61,7 +61,7 @@ namespace CustomSerialization.Protobuf.Serialization
 
         private IPersistentRepresentation PersistentFromProto(byte[] bytes)
         {
-            var persistentMessage = CustomSerialization.Protobuf.Msg.PersistentMessage.Parser.ParseFrom(bytes);
+            var persistentMessage = Msg.PersistentMessage.Parser.ParseFrom(bytes);
 
             return new Persistent(
                 payload: PayloadFromProto(persistentMessage.Payload),


### PR DESCRIPTION
We have Akka.Persistence.Redis plugin stuck on older releases of Akka.NET - this is because of some changes we made to the Akka.Persistence.TCK in [Akka.NET v1.4.10](https://github.com/akkadotnet/akka.net/releases/tag/1.4.10).