### PR TITLE
Fix Docker.DotNet.Images.ListImagesAsync

### DIFF
--- a/Akka.Persistence.Redis.sln
+++ b/Akka.Persistence.Redis.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Persistence.Redis", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Persistence.Redis.Tests", "src\Akka.Persistence.Redis.Tests\Akka.Persistence.Redis.Tests.csproj", "{59871C63-8D5D-4221-B504-203BB3500DBF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Persistence.Redis.Cluster.Test", "src\Akka.Persistence.Redis.Cluster.Test\Akka.Persistence.Redis.Cluster.Test.csproj", "{40AE5277-CA42-46DC-BA0A-CB895AFDA601}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{59871C63-8D5D-4221-B504-203BB3500DBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59871C63-8D5D-4221-B504-203BB3500DBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59871C63-8D5D-4221-B504-203BB3500DBF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40AE5277-CA42-46DC-BA0A-CB895AFDA601}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40AE5277-CA42-46DC-BA0A-CB895AFDA601}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40AE5277-CA42-46DC-BA0A-CB895AFDA601}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40AE5277-CA42-46DC-BA0A-CB895AFDA601}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Akka.Persistence.Redis.Cluster.Test/Akka.Persistence.Redis.Cluster.Test.csproj
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Akka.Persistence.Redis.Cluster.Test.csproj
@@ -1,0 +1,47 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="..\common.props" />
+
+    <PropertyGroup>
+        <AssemblyTitle>Akka.Persistence.Redis.Cluster.Tests</AssemblyTitle>
+        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    </PropertyGroup>
+
+    <!-- disable .NET Framework (Mono) on Linux-->
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+        <TargetFrameworks>$(NetCoreTestVersion)</TargetFrameworks>
+    </PropertyGroup>
+
+
+    <ItemGroup>
+        <ProjectReference Include="..\Akka.Persistence.Redis\Akka.Persistence.Redis.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+        <!-- Needed by Redis to run -->
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+        <PackageReference Include="Docker.DotNet" Version="$(DockerVersion)" />
+        <PackageReference Include="xunit" Version="$(XunitVersion)" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Akka.TestKit" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
+    </ItemGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
+</Project>

--- a/src/Akka.Persistence.Redis.Cluster.Test/DbUtils.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/DbUtils.cs
@@ -1,0 +1,39 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DbUtils.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2017 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Linq;
+using StackExchange.Redis;
+
+namespace Akka.Persistence.Redis.Cluster.Test
+{
+    public static class DbUtils
+    {
+        public static string ConnectionString { get; private set; }
+
+        public static void Initialize(RedisClusterFixture fixture)
+        {
+            ConnectionString = fixture.ConnectionString;
+        }
+        public static void Initialize(string connectionString)
+        {
+            ConnectionString = connectionString;
+        }
+
+        public static void Clean(int database)
+        {
+            var connectionString = $"{ConnectionString},allowAdmin=true";
+
+            var redisConnection = ConnectionMultiplexer.Connect(connectionString);
+            foreach (var endPoint in redisConnection.GetEndPoints(false))
+            {
+                var server = redisConnection.GetServer(endPoint);
+                if(!server.IsReplica)
+                    server.FlushAllDatabases();
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Properties/AssemblyInfo.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisAllEventsSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisAllEventsSpec.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisAllEventsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Query
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisAllEventsSpec : AllEventsSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                event-adapters {{
+                  color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+                }}
+                event-adapter-bindings = {{
+                  ""System.String"" = color-tagger
+                }}
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisAllEventsSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisAllEventsSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisCurrentAllEventsSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisCurrentAllEventsSpec.cs
@@ -1,0 +1,57 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisCurrentAllEventsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Query
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisCurrentAllEventsSpec : CurrentAllEventsSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                event-adapters {{
+                  color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+                }}
+                event-adapter-bindings = {{
+                  ""System.String"" = color-tagger
+                }}
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisCurrentAllEventsSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisCurrentAllEventsSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisCurrentEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisCurrentEventsByPersistenceIdSpec.cs
@@ -1,0 +1,50 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisCurrentEventsByPersistenceIdSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Query
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisCurrentEventsByPersistenceIdSpec : CurrentEventsByPersistenceIdSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+                        .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisCurrentEventsByPersistenceIdSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisCurrentEventsByPersistenceIdSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisCurrentEventsByTagSpec.cs
@@ -1,0 +1,57 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisCurrentEventsByTagSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Query
+{
+    [Collection("RedisClusterSpec")]
+    public sealed class RedisCurrentEventsByTagSpec : CurrentEventsByTagSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                event-adapters {{
+                  color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+                }}
+                event-adapter-bindings = {{
+                  ""System.String"" = color-tagger
+                }}
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+                key-prefix = ""sbtech:""
+            }}
+            akka.test.single-expect-default = 3s")
+                        .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisCurrentEventsByTagSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisCurrentEventsByTagSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisCurrentPersistenceIdsSpec.cs
@@ -1,0 +1,50 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisCurrentPersistenceIdsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Query
+{
+    [Collection("RedisClusterSpec")]
+    public sealed class RedisCurrentPersistenceIdsSpec : CurrentPersistenceIdsSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+                       .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisCurrentPersistenceIdsSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisCurrentPersistenceIdsSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+        
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisEventsByPersistenceIdSpec.cs
@@ -1,0 +1,50 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisEventsByPersistenceIdSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Query
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisEventsByPersistenceIdSpec : EventsByPersistenceIdSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisEventsByPersistenceIdSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisEventsByPersistenceIdSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisEventsByTagSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisEventsByTagSpec.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisEventsByTagSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Query
+{
+    [Collection("RedisClusterSpec")]
+    public sealed class RedisEventsByTagSpec : EventsByTagSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                event-adapters {{
+                  color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+                }}
+                event-adapter-bindings = {{
+                  ""System.String"" = color-tagger
+                }}
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisEventsByTagSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisEventsByTagSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Query/RedisPersistenceIdsSpec.cs
@@ -1,0 +1,82 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisPersistenceIdsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Persistence.Redis.Query;
+using Akka.Persistence.TCK.Query;
+using Akka.Streams.TestKit;
+using Akka.Util.Internal;
+using StackExchange.Redis;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Query
+{
+    [Collection("RedisClusterSpec")]
+    public sealed class RedisPersistenceIdsSpec : PersistenceIdsSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisPersistenceIdsSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisPersistenceIdsSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<RedisReadJournal>(RedisReadJournal.Identifier);
+        }
+        [Fact(Skip = "Not implemented in Redis plugin")]
+        public override Task ReadJournal_should_deallocate_AllPersistenceIds_publisher_when_the_last_subscriber_left()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public void ReadJournal_AllPersistenceIds_should_fail_the_stage_on_connection_error()
+        {
+            // setup redis
+            var address = Sys.Settings.Config.GetString("akka.persistence.journal.redis.configuration-string");
+            var database = Sys.Settings.Config.GetInt("akka.persistence.journal.redis.database");
+
+            var redis = ConnectionMultiplexer.Connect(address).GetDatabase(database);
+
+            var queries = ReadJournal.AsInstanceOf<IPersistenceIdsQuery>();
+
+            Setup("a", 1);
+
+            var source = queries.PersistenceIds();
+            var probe = source.RunWith(this.SinkProbe<string>(), Materializer);
+
+            //// change type of value
+            redis.StringSet("journal:persistenceIds", "1");
+
+            probe.Within(TimeSpan.FromSeconds(10), () => probe.Request(1).ExpectError());
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DbUtils.Clean(Database);
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/RedisClusterFixture.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/RedisClusterFixture.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Akka.Util;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Cluster.Test
+{
+    [CollectionDefinition("RedisClusterSpec")]
+    public sealed class RedisSpecsFixture : ICollectionFixture<RedisClusterFixture>
+    {
+    }
+
+    public class RedisClusterFixture : IAsyncLifetime
+    {
+        protected readonly string RedisContainerName = $"redis-cluster-{Guid.NewGuid():N}";
+        protected DockerClient Client;
+
+        public RedisClusterFixture()
+        {
+            DockerClientConfiguration config;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
+            else
+                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+
+            Client = config.CreateClient();
+        }
+
+        protected string RedisImageName => "grokzen/redis-cluster";
+
+        public string ConnectionString { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            var images = await Client.Images.ListImagesAsync(new ImagesListParameters { MatchName = RedisImageName });
+            if (images.Count == 0)
+                await Client.Images.CreateImageAsync(
+                    new ImagesCreateParameters { FromImage = RedisImageName, Tag = "latest" }, null,
+                    new Progress<JSONMessage>(message =>
+                    {
+                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
+                            ? message.ErrorMessage
+                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
+                    }));
+
+            var redisHostPort = ThreadLocalRandom.Current.Next(9000, 10000);
+
+            // create the container
+            await Client.Containers.CreateContainerAsync(new CreateContainerParameters
+            {
+                Image = RedisImageName,
+                Name = RedisContainerName,
+                Tty = true,
+                Env = new List<string>
+                {
+                    "IP=0.0.0.0",
+                    $"INITIAL_PORT={redisHostPort}"
+                },
+                ExposedPorts = new Dictionary<string, EmptyStruct>
+                {
+                    {$"{redisHostPort}/tcp", new EmptyStruct()},
+                    {$"{redisHostPort + 1}/tcp", new EmptyStruct()},
+                    {$"{redisHostPort + 2}/tcp", new EmptyStruct()},
+                    {$"{redisHostPort + 3}/tcp", new EmptyStruct()},
+                    {$"{redisHostPort + 4}/tcp", new EmptyStruct()},
+                    {$"{redisHostPort + 5}/tcp", new EmptyStruct()},
+                },
+                HostConfig = new HostConfig
+                {
+                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    {
+                        {
+                            $"{redisHostPort}/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{redisHostPort}"
+                                }
+                            }
+                        },
+                        {
+                            $"{redisHostPort + 1}/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{redisHostPort + 1}"
+                                }
+                            }
+                        },
+                        {
+                            $"{redisHostPort + 2}/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{redisHostPort + 2}"
+                                }
+                            }
+                        },
+                        {
+                            $"{redisHostPort + 3}/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{redisHostPort + 3}"
+                                }
+                            }
+                        },
+                        {
+                            $"{redisHostPort + 4}/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{redisHostPort + 4}"
+                                }
+                            }
+                        },
+                        {
+                            $"{redisHostPort + 5}/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{redisHostPort + 5}"
+                                }
+                            }
+                        },
+                    }
+                },
+            });
+
+            // start the container
+            await Client.Containers.StartContainerAsync(RedisContainerName, new ContainerStartParameters());
+
+            // Provide a 10 second startup delay
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            ConnectionString = $"127.0.0.1:{redisHostPort}";
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (Client != null)
+            {
+                // Delay to make sure that all tests has completed cleanup.
+                await Task.Delay(TimeSpan.FromSeconds(5));
+
+                // Kill the container, we can't simply stop the container because Redis can hung indefinetly
+                // if we simply stop the container.
+                await Client.Containers.KillContainerAsync(RedisContainerName, new ContainerKillParameters());
+
+                await Client.Containers.RemoveContainerAsync(RedisContainerName,
+                    new ContainerRemoveParameters { Force = true });
+                Client.Dispose();
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/RedisJournalPerfSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/RedisJournalPerfSpec.cs
@@ -1,0 +1,52 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisJournalPerfSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Configuration;
+using Akka.Persistence.TestKit.Performance;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisJournalPerfSpec : JournalPerfSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig())
+            .WithFallback(Persistence.DefaultConfig());
+        }
+
+        public RedisJournalPerfSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisJournalPerfSpec), output)
+        {
+            EventsCount = 1000;
+            ExpectDuration = TimeSpan.FromMinutes(10);
+            MeasurementIterations = 1;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            DbUtils.Clean(Database);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/RedisJournalSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/RedisJournalSpec.cs
@@ -1,0 +1,51 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.TCK.Journal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisJournalSpec : JournalSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{DbUtils.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisJournalSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisJournalSpec), output)
+        {
+            RedisPersistence.Get(Sys);
+            Initialize();
+        }
+
+        protected override bool SupportsRejectingNonSerializableObjects { get; } = false;
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            DbUtils.Clean(Database);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/RedisSettingsSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/RedisSettingsSpec.cs
@@ -1,0 +1,34 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisSettingsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Cluster.Test
+{
+    public class RedisSettingsSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        [Fact]
+        public void Redis_JournalSettings_must_have_default_values()
+        {
+            var redisPersistence = RedisPersistence.Get(Sys);
+
+            redisPersistence.JournalSettings.ConfigurationString.Should().Be(string.Empty);
+            redisPersistence.JournalSettings.Database.Should().Be(0);
+            redisPersistence.JournalSettings.KeyPrefix.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void Redis_SnapshotStoreSettingsSettings_must_have_default_values()
+        {
+            var redisPersistence = RedisPersistence.Get(Sys);
+
+            redisPersistence.SnapshotStoreSettings.ConfigurationString.Should().Be(string.Empty);
+            redisPersistence.SnapshotStoreSettings.Database.Should().Be(0);
+            redisPersistence.SnapshotStoreSettings.KeyPrefix.Should().Be(string.Empty);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/RedisSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/RedisSnapshotStoreSpec.cs
@@ -1,0 +1,63 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisSnapshotStoreSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.TCK.Snapshot;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisSnapshotStoreSpec : SnapshotStoreSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+                akka.test.single-expect-default = 3s
+                akka.persistence {{
+                    publish-plugin-commands = on
+                    snapshot-store {{
+                        plugin = ""akka.persistence.snapshot-store.redis""
+                        redis {{
+                            class = ""Akka.Persistence.Redis.Snapshot.RedisSnapshotStore, Akka.Persistence.Redis""
+                            configuration-string = ""{fixture.ConnectionString}""
+                            plugin-dispatcher = ""akka.actor.default-dispatcher""
+                            database = ""{id}""
+                        }}
+                    }}
+                }}
+                akka.actor {{
+                    serializers {{
+                        persistence-snapshot = ""Akka.Persistence.Redis.Serialization.PersistentSnapshotSerializer, Akka.Persistence.Redis""
+                    }}
+                    serialization-bindings {{
+                        ""Akka.Persistence.SelectedSnapshot, Akka.Persistence"" = persistence-snapshot
+                    }}
+                    serialization-identifiers {{
+                        ""Akka.Persistence.Redis.Serialization.PersistentSnapshotSerializer, Akka.Persistence.Redis"" = 48
+                    }}
+                }}").WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisSnapshotStoreSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture, Database), nameof(RedisSnapshotStoreSpec), output)
+        {
+            RedisPersistence.Get(Sys);
+            Initialize();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            DbUtils.Clean(Database);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Serialization/RedisJournalSerializationSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Serialization/RedisJournalSerializationSpec.cs
@@ -1,0 +1,59 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisJournalSerializationSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.TCK.Serialization;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Serialization
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisJournalSerializationSpec : JournalSerializationSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+            akka.persistence.journal.redis {{
+                event-adapters {{
+                    my-adapter = ""Akka.Persistence.TCK.Serialization.TestJournal+MyWriteAdapter, Akka.Persistence.TCK""
+                }}
+                event-adapter-bindings = {{
+                    ""Akka.Persistence.TCK.Serialization.TestJournal+MyPayload3, Akka.Persistence.TCK"" = my-adapter
+                }}
+                class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                configuration-string = ""{fixture.ConnectionString}""
+                database = {id}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisJournalSerializationSpec(ITestOutputHelper output, RedisClusterFixture fixture) : base(Config(fixture, Database), nameof(RedisJournalSerializationSpec), output)
+        {
+        }
+
+        [Fact(Skip = "Unknown whether this test is correct or not, skip for now.")]
+        public override void Journal_should_serialize_Persistent_with_EventAdapter_manifest()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            DbUtils.Clean(Database);
+        }
+
+        protected override bool SupportsSerialization => false;
+    }
+}

--- a/src/Akka.Persistence.Redis.Cluster.Test/Serialization/RedisSnapshotStoreSerializationSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Test/Serialization/RedisSnapshotStoreSerializationSpec.cs
@@ -1,0 +1,57 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RedisSnapshotStoreSerializationSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.Redis>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.TCK.Serialization;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Redis.Cluster.Test.Serialization
+{
+    [Collection("RedisClusterSpec")]
+    public class RedisSnapshotStoreSerializationSpec : SnapshotStoreSerializationSpec
+    {
+        public const int Database = 1;
+
+        public static Config Config(RedisClusterFixture fixture, int id)
+        {
+            DbUtils.Initialize(fixture);
+
+            return ConfigurationFactory.ParseString($@"
+            akka.loglevel = INFO
+            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.redis""
+            akka.persistence.snapshot-store.redis {{
+                class = ""Akka.Persistence.Redis.Snapshot.RedisSnapshotStore, Akka.Persistence.Redis""
+                configuration-string = ""{fixture.ConnectionString}""
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+                database = {id}
+            }}
+            akka.actor {{
+                serializers {{
+                    persistence-snapshot = ""Akka.Persistence.Redis.Serialization.PersistentSnapshotSerializer, Akka.Persistence.Redis""
+                }}
+                serialization-bindings {{
+                    ""Akka.Persistence.SelectedSnapshot, Akka.Persistence"" = persistence-snapshot
+                }}
+                serialization-identifiers {{
+                    ""Akka.Persistence.Redis.Serialization.PersistentSnapshotSerializer, Akka.Persistence.Redis"" = 48
+                }}
+            }}
+            akka.test.single-expect-default = 3s")
+            .WithFallback(RedisPersistence.DefaultConfig());
+        }
+
+        public RedisSnapshotStoreSerializationSpec(ITestOutputHelper output, RedisClusterFixture fixture) : base(Config(fixture, Database), nameof(RedisSnapshotStoreSerializationSpec), output)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            DbUtils.Clean(Database);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
+++ b/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.Redis.Tests</AssemblyTitle>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/src/Akka.Persistence.Redis.Tests/RedisClusterFixture.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisClusterFixture.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Util;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Tests
+{
+    [CollectionDefinition("RedisClusterSpec")]
+    public sealed class RedisClusterSpecsFixture : ICollectionFixture<RedisClusterFixture>
+    {
+    }
+
+    public class RedisClusterFixture : IAsyncLifetime
+    {
+        protected readonly string RedisContainerName = $"redis-{Guid.NewGuid():N}";
+        protected DockerClient Client;
+
+        public RedisClusterFixture()
+        {
+            DockerClientConfiguration config;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
+            else
+                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+
+            Client = config.CreateClient();
+        }
+
+        protected string RedisImageName => "grokzen/redis-cluster";
+
+        public string ConnectionString { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            var images = await Client.Images.ListImagesAsync(new ImagesListParameters { MatchName = RedisImageName });
+            if (images.Count == 0)
+                await Client.Images.CreateImageAsync(
+                    new ImagesCreateParameters { FromImage = RedisImageName, Tag = "latest" }, null,
+                    new Progress<JSONMessage>(message =>
+                    {
+                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
+                            ? message.ErrorMessage
+                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
+                    }));
+
+            var redisHostPort = ThreadLocalRandom.Current.Next(9000, 10000);
+
+            // create the container
+            await Client.Containers.CreateContainerAsync(new CreateContainerParameters
+            {
+                Image = RedisImageName,
+                Name = RedisContainerName,
+                Tty = true,
+                ExposedPorts = new Dictionary<string, EmptyStruct>
+                {
+                    {"6379/tcp", new EmptyStruct()}
+                },
+                HostConfig = new HostConfig
+                {
+                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    {
+                        {
+                            "6379/tcp",
+                            new List<PortBinding>
+                            {
+                                new PortBinding
+                                {
+                                    HostPort = $"{redisHostPort}"
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+
+            // start the container
+            await Client.Containers.StartContainerAsync(RedisContainerName, new ContainerStartParameters());
+
+            // Provide a 30 second startup delay
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            ConnectionString = $"localhost:{redisHostPort}";
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (Client != null)
+            {
+                // Delay to make sure that all tests has completed cleanup.
+                await Task.Delay(TimeSpan.FromSeconds(5));
+
+                // Kill the container, we can't simply stop the container because Redis can hung indefinetly
+                // if we simply stop the container.
+                await Client.Containers.KillContainerAsync(RedisContainerName, new ContainerKillParameters());
+
+                await Client.Containers.RemoveContainerAsync(RedisContainerName,
+                    new ContainerRemoveParameters { Force = true });
+                Client.Dispose();
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Tests/RedisFixture.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisFixture.cs
@@ -33,7 +33,9 @@ namespace Akka.Persistence.Redis.Tests
             Client = config.CreateClient();
         }
 
-        protected string RedisImageName => "redis";
+        protected string ImageName = "redis";
+        protected string Tag = "6.0";
+        protected string RedisImageName => $"{ImageName}:{Tag}";
 
         public string ConnectionString { get; private set; }
 
@@ -42,7 +44,7 @@ namespace Akka.Persistence.Redis.Tests
             var images = await Client.Images.ListImagesAsync(new ImagesListParameters { MatchName = RedisImageName });
             if (images.Count == 0)
                 await Client.Images.CreateImageAsync(
-                    new ImagesCreateParameters { FromImage = RedisImageName, Tag = "6.0" }, null,
+                    new ImagesCreateParameters { FromImage = ImageName, Tag = Tag }, null,
                     new Progress<JSONMessage>(message =>
                     {
                         Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)

--- a/src/Akka.Persistence.Redis.Tests/RedisFixture.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisFixture.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.Redis.Tests
             var images = await Client.Images.ListImagesAsync(new ImagesListParameters { MatchName = RedisImageName });
             if (images.Count == 0)
                 await Client.Images.CreateImageAsync(
-                    new ImagesCreateParameters { FromImage = RedisImageName, Tag = "latest" }, null,
+                    new ImagesCreateParameters { FromImage = RedisImageName, Tag = "6.0" }, null,
                     new Progress<JSONMessage>(message =>
                     {
                         Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)

--- a/src/Akka.Persistence.Redis.Tests/RedisFixture.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisFixture.cs
@@ -34,14 +34,27 @@ namespace Akka.Persistence.Redis.Tests
         }
 
         protected string ImageName = "redis";
-        protected string Tag = "6.0";
+        protected string Tag = "latest";
         protected string RedisImageName => $"{ImageName}:{Tag}";
 
         public string ConnectionString { get; private set; }
 
         public async Task InitializeAsync()
         {
-            var images = await Client.Images.ListImagesAsync(new ImagesListParameters { MatchName = RedisImageName });
+
+            var images = await Client.Images.ListImagesAsync(new ImagesListParameters
+            {
+                Filters = new Dictionary<string, IDictionary<string, bool>>
+                {
+                    { 
+                        "reference", 
+                        new Dictionary<string, bool> 
+                        {
+                            {RedisImageName, true}
+                        }
+                    }
+                }
+            });
             if (images.Count == 0)
                 await Client.Images.CreateImageAsync(
                     new ImagesCreateParameters { FromImage = ImageName, Tag = Tag }, null,


### PR DESCRIPTION
Docker.DotNet.Images.ListImagesAsync docker client API changed, making it return a list of all cached images instead of the one we're looking for.

The old "MatchName" property is obsolete, use the "Filter" property instead.