### PR TITLE
added cluster distribution for Redis snapshots in order to avoid hotspots

### DIFF
--- a/src/Akka.Persistence.Redis/reference.conf
+++ b/src/Akka.Persistence.Redis/reference.conf
@@ -10,7 +10,8 @@
       # dispatcher used to drive journal actor
       plugin-dispatcher = "akka.actor.default-dispatcher"
 
-      # Redis journals key prefixes. Leave it for default or change it to appropriate value. WARNING: don't change it on production instances.
+      # Redis journals key prefixes. Leave it for default or change it to appropriate value. 
+      # WARNING: don't change it on production instances.
       key-prefix = ""
     }
   }  


### PR DESCRIPTION
the old design for the `RedisSnapshotStore` would have worked - but it would have clumped all of the snapshots for all entities into a single node. This design will distribute them in clustered Redis instances using the same algorithm as the journal.