### PR TITLE
Release 1.4.35 version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.4.35 March 23 2022 ####
+* Fix default database 0 overriding StackExchange.Redis' defaultDatabase in configuration-strings [#194](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/194)
+* Upgraded to [Akka.NET 1.4.35](https://github.com/akkadotnet/akka.net/releases/tag/1.4.35)
+
 #### 1.4.31 December 21 2021 ####
 * Upgraded to [Akka.NET 1.4.31](https://github.com/akkadotnet/akka.net/releases/tag/1.4.31)
 * [Upgraded StackExchange.Redis to 2.2.88](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/179)


### PR DESCRIPTION
* Fix default database 0 overriding StackExchange.Redis' `defaultDatabase` in `configuration-strings` [#194](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/194)
* Upgraded to [Akka.NET 1.4.35](https://github.com/akkadotnet/akka.net/releases/tag/1.4.35)