### PR TITLE
Split off perf test from test project

### DIFF
--- a/Akka.Persistence.Redis.sln
+++ b/Akka.Persistence.Redis.sln
@@ -42,6 +42,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build-system", "build-syste
 		build-system\windows-release.yaml = build-system\windows-release.yaml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Redis.Tests.Perf", "src\benchmarks\Akka.Persistence.Redis.Tests.Perf\Akka.Persistence.Redis.Tests.Perf.csproj", "{BE9CD3E1-53C4-4FDE-9DD9-DD0D4C49F234}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -76,6 +78,10 @@ Global
 		{80BD65FD-3AB6-4AF1-B0CD-573C9D50DB1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{80BD65FD-3AB6-4AF1-B0CD-573C9D50DB1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{80BD65FD-3AB6-4AF1-B0CD-573C9D50DB1E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE9CD3E1-53C4-4FDE-9DD9-DD0D4C49F234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE9CD3E1-53C4-4FDE-9DD9-DD0D4C49F234}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE9CD3E1-53C4-4FDE-9DD9-DD0D4C49F234}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE9CD3E1-53C4-4FDE-9DD9-DD0D4C49F234}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -85,6 +91,7 @@ Global
 		{90084FC1-C04B-46BF-AA37-2ACD71E1AD4F} = {1F453772-CA5E-4F41-A50E-75F3F59F72D6}
 		{BFBB3933-E8FC-4574-8D60-E6FA6BEABAE9} = {DA31E2A8-AE1A-474D-843C-1B6848B921E2}
 		{D118A7A7-A89D-450D-8218-E2AE580DEF5D} = {EB67BFB9-7589-469F-B0E0-6DDFC0032E67}
+		{BE9CD3E1-53C4-4FDE-9DD9-DD0D4C49F234} = {DA31E2A8-AE1A-474D-843C-1B6848B921E2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6ADAF1F3-8019-4D3E-A8B0-2BF7CF7B439B}

--- a/Akka.Persistence.Redis.sln.DotSettings
+++ b/Akka.Persistence.Redis.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">-----------------------------------------------------------------------&#xD;
-&lt;copyright file="$FILENAME$" company="Akka.NET Project"&gt;&#xD;
+&lt;copyright file="${File.FileName}" company="Akka.NET Project"&gt;&#xD;
      Copyright (C) 2013-2021 .NET Foundation &lt;https://github.com/akkadotnet/akka.net&gt;&#xD;
 &lt;/copyright&gt;&#xD;
------------------------------------------------------------------------</s:String></wpf:ResourceDictionary>
+-----------------------------------------------------------------------</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/Akka.Persistence.Redis.Tests.Perf.csproj
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/Akka.Persistence.Redis.Tests.Perf.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    </PropertyGroup>
+
+    <!-- disable .NET Framework (Mono) on Linux-->
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+        <TargetFramework>$(NetTestVersion)</TargetFramework>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\..\Akka.Persistence.Redis\Akka.Persistence.Redis.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Docker.DotNet" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Akka.TestKit" />
+        <PackageReference Include="Akka.Persistence.TCK" />
+        <PackageReference Include="Akka.TestKit.Xunit2" />
+        <PackageReference Include="Akka.Streams.TestKit" />
+    </ItemGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+    </PropertyGroup>
+</Project>

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/DbUtils.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/DbUtils.cs
@@ -1,0 +1,44 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="DbUtils.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Persistence.Redis.Cluster.Tests;
+using StackExchange.Redis;
+
+namespace Akka.Persistence.Redis.Tests.Perf
+{
+    public static class DbUtils
+    {
+        public static string ConnectionString { get; private set; } = string.Empty;
+
+        public static void Initialize(RedisClusterFixture fixture)
+        {
+            ConnectionString = fixture.ConnectionString;
+        }
+
+        public static void Initialize(RedisFixture fixture)
+        {
+            ConnectionString = fixture.ConnectionString;
+        }
+
+        public static void Initialize(string connectionString)
+        {
+            ConnectionString = connectionString;
+        }
+
+        public static void Clean(int database = -1)
+        {
+            var connectionString = $"{ConnectionString},allowAdmin=true";
+
+            var redisConnection = ConnectionMultiplexer.Connect(connectionString);
+            foreach (var endPoint in redisConnection.GetEndPoints(false))
+            {
+                var server = redisConnection.GetServer(endPoint);
+                if (!server.IsReplica)
+                    server.FlushAllDatabases();
+            }
+        }
+    }
+}

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterFixture.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterFixture.cs
@@ -1,0 +1,143 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="RedisClusterFixture.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Akka.Util;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Cluster.Tests
+{
+    [CollectionDefinition("RedisClusterSpec")]
+    public sealed class RedisSpecsFixture : ICollectionFixture<RedisClusterFixture>
+    {
+    }
+
+    public class RedisClusterFixture : IAsyncLifetime
+    {
+        protected readonly string RedisContainerName = $"redis-cluster-{Guid.NewGuid():N}";
+        protected DockerClient Client;
+
+        public RedisClusterFixture()
+        {
+            DockerClientConfiguration config;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
+            else
+                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+
+            Client = config.CreateClient();
+        }
+
+        protected string ImageName => "grokzen/redis-cluster";
+        protected string Tag => "6.0.13";
+        protected string RedisImageName => $"{ImageName}:{Tag}";
+
+        public string ConnectionString { get; private set; } = string.Empty;
+
+        public async Task InitializeAsync()
+        {
+            var images = await Client.Images.ListImagesAsync(new ImagesListParameters
+            {
+                Filters = new Dictionary<string, IDictionary<string, bool>>
+                {
+                    {"reference", new Dictionary<string, bool> {{RedisImageName, true}}}
+                }
+            });
+            if (images.Count == 0)
+                await Client.Images.CreateImageAsync(
+                    new ImagesCreateParameters {FromImage = RedisImageName, Tag = Tag}, null,
+                    new Progress<JSONMessage>(message =>
+                    {
+                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
+                            ? message.ErrorMessage
+                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
+                    }));
+
+            var redisHostPort = ThreadLocalRandom.Current.Next(9000, 10000);
+
+            // create the container
+            await Client.Containers.CreateContainerAsync(new CreateContainerParameters
+            {
+                Image = RedisImageName,
+                Name = RedisContainerName,
+                Tty = true,
+                Env = new List<string> {"IP=0.0.0.0", $"INITIAL_PORT={redisHostPort}"},
+                ExposedPorts =
+                    new Dictionary<string, EmptyStruct>
+                    {
+                        {$"{redisHostPort}/tcp", new EmptyStruct()},
+                        {$"{redisHostPort + 1}/tcp", new EmptyStruct()},
+                        {$"{redisHostPort + 2}/tcp", new EmptyStruct()},
+                        {$"{redisHostPort + 3}/tcp", new EmptyStruct()},
+                        {$"{redisHostPort + 4}/tcp", new EmptyStruct()},
+                        {$"{redisHostPort + 5}/tcp", new EmptyStruct()}
+                    },
+                HostConfig = new HostConfig
+                {
+                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    {
+                        {
+                            $"{redisHostPort}/tcp",
+                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort}"}}
+                        },
+                        {
+                            $"{redisHostPort + 1}/tcp",
+                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 1}"}}
+                        },
+                        {
+                            $"{redisHostPort + 2}/tcp",
+                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 2}"}}
+                        },
+                        {
+                            $"{redisHostPort + 3}/tcp",
+                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 3}"}}
+                        },
+                        {
+                            $"{redisHostPort + 4}/tcp",
+                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 4}"}}
+                        },
+                        {
+                            $"{redisHostPort + 5}/tcp",
+                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 5}"}}
+                        }
+                    }
+                }
+            });
+
+            // start the container
+            await Client.Containers.StartContainerAsync(RedisContainerName, new ContainerStartParameters());
+
+            // Provide a 10 second startup delay
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            ConnectionString = $"127.0.0.1:{redisHostPort}";
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (Client != null)
+            {
+                // Delay to make sure that all tests has completed cleanup.
+                await Task.Delay(TimeSpan.FromSeconds(5));
+
+                // Kill the container, we can't simply stop the container because Redis can hung indefinetly
+                // if we simply stop the container.
+                await Client.Containers.KillContainerAsync(RedisContainerName, new ContainerKillParameters());
+
+                await Client.Containers.RemoveContainerAsync(RedisContainerName,
+                    new ContainerRemoveParameters {Force = true});
+                Client.Dispose();
+            }
+        }
+    }
+}

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterJournalPerfSpec.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterJournalPerfSpec.cs
@@ -5,14 +5,15 @@
 // -----------------------------------------------------------------------
 
 using Akka.Configuration;
+using Akka.Persistence.Redis.Cluster.Tests;
 using Akka.Persistence.TestKit.Performance;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Akka.Persistence.Redis.Cluster.Tests
+namespace Akka.Persistence.Redis.Tests.Perf
 {
     [Collection("RedisClusterSpec")]
-    public class RedisJournalPerfSpec : JournalPerfSpec
+    public class RedisClusterJournalPerfSpec : JournalPerfSpec
     {
         public static Config Config(RedisClusterFixture fixture)
         {
@@ -31,8 +32,8 @@ namespace Akka.Persistence.Redis.Cluster.Tests
                 .WithFallback(Persistence.DefaultConfig());
         }
 
-        public RedisJournalPerfSpec(ITestOutputHelper output, RedisClusterFixture fixture)
-            : base(Config(fixture), nameof(RedisJournalPerfSpec), output)
+        public RedisClusterJournalPerfSpec(ITestOutputHelper output, RedisClusterFixture fixture)
+            : base(Config(fixture), nameof(RedisClusterJournalPerfSpec), output)
         {
         }
 

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisFixture.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisFixture.cs
@@ -1,0 +1,125 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="RedisFixture.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Akka.Util;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Tests
+{
+    [CollectionDefinition("RedisSpec")]
+    public sealed class RedisSpecsFixture : ICollectionFixture<RedisFixture>
+    {
+    }
+
+    public class RedisFixture : IAsyncLifetime
+    {
+        protected readonly string RedisContainerName = $"redis-{Guid.NewGuid():N}";
+        protected readonly string RedisContainerName2 = $"redis-{Guid.NewGuid():N}";
+        protected DockerClient Client;
+
+        public RedisFixture()
+        {
+            DockerClientConfiguration config;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
+            else
+                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+
+            Client = config.CreateClient();
+        }
+
+        protected string ImageName => "redis";
+        protected string Tag => "latest";
+        protected string RedisImageName => $"{ImageName}:{Tag}";
+
+        public string ConnectionString { get; private set; } = string.Empty;
+
+        public async Task InitializeAsync()
+        {
+            var images = await Client.Images.ListImagesAsync(new ImagesListParameters
+            {
+                Filters = new Dictionary<string, IDictionary<string, bool>>
+                {
+                    {"reference", new Dictionary<string, bool> {{RedisImageName, true}}}
+                }
+            });
+            if (images.Count == 0)
+                await Client.Images.CreateImageAsync(
+                    new ImagesCreateParameters {FromImage = ImageName, Tag = Tag}, null,
+                    new Progress<JSONMessage>(message =>
+                    {
+                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
+                            ? message.ErrorMessage
+                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
+                    }));
+
+            var redisHostPort1 = ThreadLocalRandom.Current.Next(9000, 10000);
+            var redisHostPort2 = ThreadLocalRandom.Current.Next(9000, 10000);
+
+            await CreateContainer(redisHostPort1, RedisContainerName);
+            await CreateContainer(redisHostPort2, RedisContainerName2);
+
+            ConnectionString = $"localhost:{redisHostPort1},localhost:{redisHostPort2}"; 
+        }
+        private async ValueTask CreateContainer(int redisHostPort, string redisContainerName)
+        {
+            // create the container
+            await Client.Containers.CreateContainerAsync(new CreateContainerParameters
+            {
+                Image = RedisImageName,
+                Name = redisContainerName,
+                Tty = true,
+                ExposedPorts = new Dictionary<string, EmptyStruct> { { "6379/tcp", new EmptyStruct() } },
+                HostConfig = new HostConfig
+                {
+                    PortBindings = new Dictionary<string, IList<PortBinding>>
+                    {
+                        {
+                            "6379/tcp", new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort}"}}
+                        }
+                    }
+                }
+            });
+
+
+            // start the container
+            await Client.Containers.StartContainerAsync(redisContainerName, new ContainerStartParameters());
+
+            // Provide a 30 second startup delay
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+        public async Task DisposeAsync()
+        {
+            if (Client != null)
+            {
+                // Delay to make sure that all tests has completed cleanup.
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                await KillContainer(RedisContainerName);
+                await KillContainer(RedisContainerName2);
+               
+                Client.Dispose();
+            }
+        }
+        private async ValueTask KillContainer(string container)
+        {
+            // Kill the container, we can't simply stop the container because Redis can hung indefinetly
+            // if we simply stop the container.
+            await Client.Containers.KillContainerAsync(container, new ContainerKillParameters());
+
+            await Client.Containers.RemoveContainerAsync(container,
+                new ContainerRemoveParameters { Force = true });
+        }
+    }
+}

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisJournalPerfSpec.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisJournalPerfSpec.cs
@@ -4,13 +4,12 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using Akka.Configuration;
 using Akka.Persistence.TestKit.Performance;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Akka.Persistence.Redis.Tests
+namespace Akka.Persistence.Redis.Tests.Perf
 {
     [Collection("RedisSpec")]
     public class RedisJournalPerfSpec : JournalPerfSpec


### PR DESCRIPTION
Implementing the performance test inside the test project does not make sense, splitting them into their own project to cut down CI/CD build time and stop CI/CD from failing because of failing perf test.