### PR TITLE
Release 1.5.53

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2023 Akka.NET Project</Copyright>
     <Authors>Akka.NET</Authors>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.5.53</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Akka.NET Persistence journal and snapshot store backed by Redis.</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -34,7 +34,10 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.Redis</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageReleaseNotes>Upgraded to [Akka.NET 1.5.0](https://github.com/akkadotnet/akka.net/releases/tag/1.5.0)
-Upgraded [StackExchange.Redis 2.6.86](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/232)</PackageReleaseNotes>
+    <PackageReleaseNotes>* Upgraded to [Akka.NET 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
+* Upgraded to [Akka.Hosting 1.5.53](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.53)
+* [Added Microsoft.Extensions.Diagnostics.HealthChecks integration](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/445)
+* [Bump Akka.Cluster.Sharding to 1.5.51](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/440)
+* [Bump StackExchange.Redis to 2.8.31](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/406)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 1.5.53 October 16th 2025 ####
+
+* Upgraded to [Akka.NET 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
+* Upgraded to [Akka.Hosting 1.5.53](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.53)
+* [Added Microsoft.Extensions.Diagnostics.HealthChecks integration](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/445)
+* [Bump Akka.Cluster.Sharding to 1.5.51](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/440)
+* [Bump StackExchange.Redis to 2.8.31](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/406)
+
 #### 1.5.42 May 22nd 2025 ####
 
 * Upgraded to [Akka.NET 1.5.42](https://github.com/akkadotnet/akka.net/releases/tag/1.5.37)


### PR DESCRIPTION
## Summary

Prepare for version 1.5.53 release with the following changes:

- Upgraded to Akka.NET 1.5.53
- Upgraded to Akka.Hosting 1.5.53
- Added Microsoft.Extensions.Diagnostics.HealthChecks integration
- Bump Akka.Cluster.Sharding to 1.5.51
- Bump StackExchange.Redis to 2.8.31

## Changes

- Updated `Directory.Build.props` with version 1.5.53
- Updated `RELEASE_NOTES.md` with release notes

## Test Plan

- Build and test passed locally
- All version metadata updated correctly