### PR TITLE
Upgrade to Akka.Hosting v1.5.55 stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AkkaVersion>1.5.55</AkkaVersion>
-    <AkkaHostingVersion>1.5.55-beta1</AkkaHostingVersion>
+    <AkkaHostingVersion>1.5.55</AkkaHostingVersion>
   </PropertyGroup>
   <!-- Library dependencies -->
   <ItemGroup>


### PR DESCRIPTION
Upgrades from Akka.Hosting v1.5.55-beta1 to stable v1.5.55 release.