### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2023 Akka.NET Project</Copyright>
     <Authors>Akka.NET</Authors>
-    <VersionPrefix>1.5.53</VersionPrefix>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Akka.NET Persistence journal and snapshot store backed by Redis.</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -34,10 +34,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.Redis</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageReleaseNotes>* Upgraded to [Akka.NET 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
-* Upgraded to [Akka.Hosting 1.5.53](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.53)
-* [Added Microsoft.Extensions.Diagnostics.HealthChecks integration](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/445)
-* [Bump Akka.Cluster.Sharding to 1.5.51](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/440)
-* [Bump StackExchange.Redis to 2.8.31](https://github.com/akkadotnet/Akka.Persistence.Redis/pull/406)</PackageReleaseNotes>
+    <PackageReleaseNotes>* Upgraded to [Akka.NET 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* Upgraded to [Akka.Hosting 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.55</AkkaVersion>
-    <AkkaHostingVersion>1.5.55.1</AkkaHostingVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
+    <AkkaHostingVersion>1.5.59</AkkaHostingVersion>
   </PropertyGroup>
   <!-- Library dependencies -->
   <ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.59 December 18th 2025 ####
+
+* Upgraded to [Akka.NET 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* Upgraded to [Akka.Hosting 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)
+
 #### 1.5.55.1 October 29th 2025 ####
 
 **Improved API**


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59
- Upgrade Akka.Hosting to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
- [Akka.Hosting 1.5.59 Release Notes](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)