### PR TITLE
Bump Akka.NET to 1.5.60

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.59</AkkaVersion>
-    <AkkaHostingVersion>1.5.59</AkkaHostingVersion>
+    <AkkaVersion>1.5.60</AkkaVersion>
+    <AkkaHostingVersion>1.5.60</AkkaHostingVersion>
   </PropertyGroup>
   <!-- Library dependencies -->
   <ItemGroup>
@@ -21,7 +21,7 @@
     <PackageVersion Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <PackageVersion Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
## Summary

Bumps AkkaVersion and AkkaHostingVersion to 1.5.60, along with an update to Microsoft.Extensions.Hosting from 6.0.1 to 8.0.0 to resolve dependency conflicts.

## Changes

- AkkaVersion: 1.5.59 → 1.5.60
- AkkaHostingVersion: 1.5.59 → 1.5.60
- Microsoft.Extensions.Hosting: 6.0.1 → 8.0.0

The Microsoft.Extensions.Hosting update was necessary because Akka.Hosting.TestKit 1.5.60 requires version 8.0.0 or higher.

## Test plan

- Build passes successfully
- No breaking changes expected