### PR TITLE
Migrate test fixtures from Docker.DotNet to Testcontainers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,8 @@
     <PackageVersion Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Akka.Persistence.Redis.Cluster.Tests/Akka.Persistence.Redis.Cluster.Tests.csproj
+++ b/src/Akka.Persistence.Redis.Cluster.Tests/Akka.Persistence.Redis.Cluster.Tests.csproj
@@ -22,7 +22,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="Docker.DotNet" />
+        <PackageReference Include="Testcontainers" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Akka.Persistence.Redis.Cluster.Tests/RedisClusterFixture.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Tests/RedisClusterFixture.cs
@@ -1,16 +1,13 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RedisClusterFixture.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Akka.Util;
-using Docker.DotNet;
-using Docker.DotNet.Models;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
 using Xunit;
 
 namespace Akka.Persistence.Redis.Cluster.Tests
@@ -22,122 +19,38 @@ namespace Akka.Persistence.Redis.Cluster.Tests
 
     public class RedisClusterFixture : IAsyncLifetime
     {
-        protected readonly string RedisContainerName = $"redis-cluster-{Guid.NewGuid():N}";
-        protected DockerClient Client;
+        // grokzen/redis-cluster gossips its node addresses based on INITIAL_PORT / IP, so the
+        // container's published ports must match the host ports SE.Redis later connects to.
+        private readonly int _basePort = ThreadLocalRandom.Current.Next(9000, 10000);
 
-        public RedisClusterFixture()
-        {
-            DockerClientConfiguration config;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
-            else
-                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+        private IContainer _container = null!;
 
-            Client = config.CreateClient();
-        }
-
-        protected string ImageName => "grokzen/redis-cluster";
-        protected string Tag => "6.0.13";
-        protected string RedisImageName => $"{ImageName}:{Tag}";
-
-        public string ConnectionString { get; private set; }
+        public string ConnectionString { get; private set; } = string.Empty;
 
         public async ValueTask InitializeAsync()
         {
-            var images = await Client.Images.ListImagesAsync(new ImagesListParameters
+            var builder = new ContainerBuilder("grokzen/redis-cluster:6.0.13")
+                .WithEnvironment("IP", "0.0.0.0")
+                .WithEnvironment("INITIAL_PORT", _basePort.ToString())
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Cluster state changed: ok"));
+
+            for (var offset = 0; offset < 6; offset++)
             {
-                Filters = new Dictionary<string, IDictionary<string, bool>>
-                {
-                    {"reference", new Dictionary<string, bool> {{RedisImageName, true}}}
-                }
-            });
-            if (images.Count == 0)
-                await Client.Images.CreateImageAsync(
-                    new ImagesCreateParameters {FromImage = RedisImageName, Tag = Tag}, null,
-                    new Progress<JSONMessage>(message =>
-                    {
-                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
-                            ? message.ErrorMessage
-                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
-                    }));
+                var port = _basePort + offset;
+                builder = builder.WithPortBinding(port, port);
+            }
 
-            var redisHostPort = ThreadLocalRandom.Current.Next(9000, 10000);
+            _container = builder.Build();
 
-            // create the container
-            await Client.Containers.CreateContainerAsync(new CreateContainerParameters
-            {
-                Image = RedisImageName,
-                Name = RedisContainerName,
-                Tty = true,
-                Env = new List<string> {"IP=0.0.0.0", $"INITIAL_PORT={redisHostPort}"},
-                ExposedPorts =
-                    new Dictionary<string, EmptyStruct>
-                    {
-                        {$"{redisHostPort}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 1}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 2}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 3}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 4}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 5}/tcp", new EmptyStruct()}
-                    },
-                HostConfig = new HostConfig
-                {
-                    PortBindings = new Dictionary<string, IList<PortBinding>>
-                    {
-                        {
-                            $"{redisHostPort}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort}"}}
-                        },
-                        {
-                            $"{redisHostPort + 1}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 1}"}}
-                        },
-                        {
-                            $"{redisHostPort + 2}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 2}"}}
-                        },
-                        {
-                            $"{redisHostPort + 3}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 3}"}}
-                        },
-                        {
-                            $"{redisHostPort + 4}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 4}"}}
-                        },
-                        {
-                            $"{redisHostPort + 5}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 5}"}}
-                        }
-                    }
-                }
-            });
+            await _container.StartAsync();
 
-            // start the container
-            await Client.Containers.StartContainerAsync(RedisContainerName, new ContainerStartParameters());
-
-            // Provide a 10 second startup delay
-            await Task.Delay(TimeSpan.FromSeconds(10));
-
-            ConnectionString = $"127.0.0.1:{redisHostPort}";
+            ConnectionString = $"127.0.0.1:{_basePort}";
         }
 
         public async ValueTask DisposeAsync()
         {
-            if (Client != null)
-            {
-                // Delay to make sure that all tests has completed cleanup.
-                await Task.Delay(TimeSpan.FromSeconds(5));
-
-                // Kill the container, we can't simply stop the container because Redis can hung indefinetly
-                // if we simply stop the container.
-                await Client.Containers.KillContainerAsync(RedisContainerName, new ContainerKillParameters());
-
-                await Client.Containers.RemoveContainerAsync(RedisContainerName,
-                    new ContainerRemoveParameters {Force = true});
-                Client.Dispose();
-            }
+            if (_container is not null)
+                await _container.DisposeAsync();
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
+++ b/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
@@ -20,7 +20,8 @@
     <PackageReference Include="Akka.Hosting.TestKit" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Docker.DotNet" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Testcontainers.Redis" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>

--- a/src/Akka.Persistence.Redis.Tests/RedisFixture.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisFixture.cs
@@ -1,17 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RedisFixture.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Akka.Util;
-using Docker.DotNet;
-using Docker.DotNet.Models;
+using Testcontainers.Redis;
 using Xunit;
 
 namespace Akka.Persistence.Redis.Tests
@@ -23,103 +17,24 @@ namespace Akka.Persistence.Redis.Tests
 
     public class RedisFixture : IAsyncLifetime
     {
-        protected readonly string RedisContainerName = $"redis-{Guid.NewGuid():N}";
-        protected readonly string RedisContainerName2 = $"redis-{Guid.NewGuid():N}";
-        protected DockerClient Client;
+        private readonly RedisContainer _container1 = new RedisBuilder("redis:latest").Build();
 
-        public RedisFixture()
-        {
-            DockerClientConfiguration config;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
-            else
-                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
+        private readonly RedisContainer _container2 = new RedisBuilder("redis:latest").Build();
 
-            Client = config.CreateClient();
-        }
-
-        protected string ImageName => "redis";
-        protected string Tag => "latest";
-        protected string RedisImageName => $"{ImageName}:{Tag}";
-
-        public string ConnectionString { get; private set; }
+        public string ConnectionString { get; private set; } = string.Empty;
 
         public async ValueTask InitializeAsync()
         {
-            var images = await Client.Images.ListImagesAsync(new ImagesListParameters
-            {
-                Filters = new Dictionary<string, IDictionary<string, bool>>
-                {
-                    {"reference", new Dictionary<string, bool> {{RedisImageName, true}}}
-                }
-            });
-            if (images.Count == 0)
-                await Client.Images.CreateImageAsync(
-                    new ImagesCreateParameters {FromImage = ImageName, Tag = Tag}, null,
-                    new Progress<JSONMessage>(message =>
-                    {
-                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
-                            ? message.ErrorMessage
-                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
-                    }));
+            await Task.WhenAll(_container1.StartAsync(), _container2.StartAsync());
 
-            var redisHostPort1 = ThreadLocalRandom.Current.Next(9000, 10000);
-            var redisHostPort2 = ThreadLocalRandom.Current.Next(9000, 10000);
-
-            await CreateContainer(redisHostPort1, RedisContainerName);
-            await CreateContainer(redisHostPort2, RedisContainerName2);
-
-            ConnectionString = $"localhost:{redisHostPort1},localhost:{redisHostPort2}"; 
+            ConnectionString = $"{_container1.GetConnectionString()},{_container2.GetConnectionString()}";
         }
-        private async ValueTask CreateContainer(int redisHostPort, string redisContainerName)
-        {
-            // create the container
-            await Client.Containers.CreateContainerAsync(new CreateContainerParameters
-            {
-                Image = RedisImageName,
-                Name = redisContainerName,
-                Tty = true,
-                ExposedPorts = new Dictionary<string, EmptyStruct> { { "6379/tcp", new EmptyStruct() } },
-                HostConfig = new HostConfig
-                {
-                    PortBindings = new Dictionary<string, IList<PortBinding>>
-                    {
-                        {
-                            "6379/tcp", new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort}"}}
-                        }
-                    }
-                }
-            });
 
-
-            // start the container
-            await Client.Containers.StartContainerAsync(redisContainerName, new ContainerStartParameters());
-
-            // Provide a 30 second startup delay
-            await Task.Delay(TimeSpan.FromSeconds(10));
-        }
         public async ValueTask DisposeAsync()
         {
-            if (Client != null)
-            {
-                // Delay to make sure that all tests has completed cleanup.
-                await Task.Delay(TimeSpan.FromSeconds(5));
-                await KillContainer(RedisContainerName);
-                await KillContainer(RedisContainerName2);
-               
-                Client.Dispose();
-            }
-        }
-        private async ValueTask KillContainer(string container)
-        {
-            // Kill the container, we can't simply stop the container because Redis can hung indefinetly
-            // if we simply stop the container.
-            await Client.Containers.KillContainerAsync(container, new ContainerKillParameters());
-
-            await Client.Containers.RemoveContainerAsync(container,
-                new ContainerRemoveParameters { Force = true });
+            await Task.WhenAll(
+                _container1.DisposeAsync().AsTask(),
+                _container2.DisposeAsync().AsTask());
         }
     }
 }

--- a/src/benchmarks/Akka.Persistence.Redis.Benchmark.DockerTests/Akka.Persistence.Redis.Benchmark.DockerTests.csproj
+++ b/src/benchmarks/Akka.Persistence.Redis.Benchmark.DockerTests/Akka.Persistence.Redis.Benchmark.DockerTests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Docker.DotNet" />
     <PackageReference Include="Akka" />
     <PackageReference Include="JetBrains.dotMemoryUnit" />
     <PackageReference Include="xunit.v3" />

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/Akka.Persistence.Redis.Tests.Perf.csproj
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/Akka.Persistence.Redis.Tests.Perf.csproj
@@ -23,7 +23,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="Docker.DotNet" />
+        <PackageReference Include="Testcontainers" />
+        <PackageReference Include="Testcontainers.Redis" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterFixture.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterFixture.cs
@@ -1,16 +1,13 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RedisClusterFixture.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Akka.Util;
-using Docker.DotNet;
-using Docker.DotNet.Models;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
 using Xunit;
 
 namespace Akka.Persistence.Redis.Cluster.Tests
@@ -22,122 +19,38 @@ namespace Akka.Persistence.Redis.Cluster.Tests
 
     public class RedisClusterFixture : IAsyncLifetime
     {
-        protected readonly string RedisContainerName = $"redis-cluster-{Guid.NewGuid():N}";
-        protected DockerClient Client;
+        // grokzen/redis-cluster gossips its node addresses based on INITIAL_PORT / IP, so the
+        // container's published ports must match the host ports SE.Redis later connects to.
+        private readonly int _basePort = ThreadLocalRandom.Current.Next(9000, 10000);
 
-        public RedisClusterFixture()
-        {
-            DockerClientConfiguration config;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
-            else
-                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
-
-            Client = config.CreateClient();
-        }
-
-        protected string ImageName => "grokzen/redis-cluster";
-        protected string Tag => "6.0.13";
-        protected string RedisImageName => $"{ImageName}:{Tag}";
+        private IContainer _container = null!;
 
         public string ConnectionString { get; private set; } = string.Empty;
 
         public async ValueTask InitializeAsync()
         {
-            var images = await Client.Images.ListImagesAsync(new ImagesListParameters
+            var builder = new ContainerBuilder("grokzen/redis-cluster:6.0.13")
+                .WithEnvironment("IP", "0.0.0.0")
+                .WithEnvironment("INITIAL_PORT", _basePort.ToString())
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Cluster state changed: ok"));
+
+            for (var offset = 0; offset < 6; offset++)
             {
-                Filters = new Dictionary<string, IDictionary<string, bool>>
-                {
-                    {"reference", new Dictionary<string, bool> {{RedisImageName, true}}}
-                }
-            });
-            if (images.Count == 0)
-                await Client.Images.CreateImageAsync(
-                    new ImagesCreateParameters {FromImage = RedisImageName, Tag = Tag}, null,
-                    new Progress<JSONMessage>(message =>
-                    {
-                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
-                            ? message.ErrorMessage
-                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
-                    }));
+                var port = _basePort + offset;
+                builder = builder.WithPortBinding(port, port);
+            }
 
-            var redisHostPort = ThreadLocalRandom.Current.Next(9000, 10000);
+            _container = builder.Build();
 
-            // create the container
-            await Client.Containers.CreateContainerAsync(new CreateContainerParameters
-            {
-                Image = RedisImageName,
-                Name = RedisContainerName,
-                Tty = true,
-                Env = new List<string> {"IP=0.0.0.0", $"INITIAL_PORT={redisHostPort}"},
-                ExposedPorts =
-                    new Dictionary<string, EmptyStruct>
-                    {
-                        {$"{redisHostPort}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 1}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 2}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 3}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 4}/tcp", new EmptyStruct()},
-                        {$"{redisHostPort + 5}/tcp", new EmptyStruct()}
-                    },
-                HostConfig = new HostConfig
-                {
-                    PortBindings = new Dictionary<string, IList<PortBinding>>
-                    {
-                        {
-                            $"{redisHostPort}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort}"}}
-                        },
-                        {
-                            $"{redisHostPort + 1}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 1}"}}
-                        },
-                        {
-                            $"{redisHostPort + 2}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 2}"}}
-                        },
-                        {
-                            $"{redisHostPort + 3}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 3}"}}
-                        },
-                        {
-                            $"{redisHostPort + 4}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 4}"}}
-                        },
-                        {
-                            $"{redisHostPort + 5}/tcp",
-                            new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort + 5}"}}
-                        }
-                    }
-                }
-            });
+            await _container.StartAsync();
 
-            // start the container
-            await Client.Containers.StartContainerAsync(RedisContainerName, new ContainerStartParameters());
-
-            // Provide a 10 second startup delay
-            await Task.Delay(TimeSpan.FromSeconds(10));
-
-            ConnectionString = $"127.0.0.1:{redisHostPort}";
+            ConnectionString = $"127.0.0.1:{_basePort}";
         }
 
         public async ValueTask DisposeAsync()
         {
-            if (Client != null)
-            {
-                // Delay to make sure that all tests has completed cleanup.
-                await Task.Delay(TimeSpan.FromSeconds(5));
-
-                // Kill the container, we can't simply stop the container because Redis can hung indefinetly
-                // if we simply stop the container.
-                await Client.Containers.KillContainerAsync(RedisContainerName, new ContainerKillParameters());
-
-                await Client.Containers.RemoveContainerAsync(RedisContainerName,
-                    new ContainerRemoveParameters {Force = true});
-                Client.Dispose();
-            }
+            if (_container is not null)
+                await _container.DisposeAsync();
         }
     }
 }

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisFixture.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisFixture.cs
@@ -1,17 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RedisFixture.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Akka.Util;
-using Docker.DotNet;
-using Docker.DotNet.Models;
+using Testcontainers.Redis;
 using Xunit;
 
 namespace Akka.Persistence.Redis.Tests
@@ -23,103 +17,24 @@ namespace Akka.Persistence.Redis.Tests
 
     public class RedisFixture : IAsyncLifetime
     {
-        protected readonly string RedisContainerName = $"redis-{Guid.NewGuid():N}";
-        protected readonly string RedisContainerName2 = $"redis-{Guid.NewGuid():N}";
-        protected DockerClient Client;
+        private readonly RedisContainer _container1 = new RedisBuilder("redis:latest").Build();
 
-        public RedisFixture()
-        {
-            DockerClientConfiguration config;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                config = new DockerClientConfiguration(new Uri("unix://var/run/docker.sock"));
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                config = new DockerClientConfiguration(new Uri("npipe://./pipe/docker_engine"));
-            else
-                throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
-
-            Client = config.CreateClient();
-        }
-
-        protected string ImageName => "redis";
-        protected string Tag => "latest";
-        protected string RedisImageName => $"{ImageName}:{Tag}";
+        private readonly RedisContainer _container2 = new RedisBuilder("redis:latest").Build();
 
         public string ConnectionString { get; private set; } = string.Empty;
 
         public async ValueTask InitializeAsync()
         {
-            var images = await Client.Images.ListImagesAsync(new ImagesListParameters
-            {
-                Filters = new Dictionary<string, IDictionary<string, bool>>
-                {
-                    {"reference", new Dictionary<string, bool> {{RedisImageName, true}}}
-                }
-            });
-            if (images.Count == 0)
-                await Client.Images.CreateImageAsync(
-                    new ImagesCreateParameters {FromImage = ImageName, Tag = Tag}, null,
-                    new Progress<JSONMessage>(message =>
-                    {
-                        Console.WriteLine(!string.IsNullOrEmpty(message.ErrorMessage)
-                            ? message.ErrorMessage
-                            : $"{message.ID} {message.Status} {message.ProgressMessage}");
-                    }));
+            await Task.WhenAll(_container1.StartAsync(), _container2.StartAsync());
 
-            var redisHostPort1 = ThreadLocalRandom.Current.Next(9000, 10000);
-            var redisHostPort2 = ThreadLocalRandom.Current.Next(9000, 10000);
-
-            await CreateContainer(redisHostPort1, RedisContainerName);
-            await CreateContainer(redisHostPort2, RedisContainerName2);
-
-            ConnectionString = $"localhost:{redisHostPort1},localhost:{redisHostPort2}"; 
+            ConnectionString = $"{_container1.GetConnectionString()},{_container2.GetConnectionString()}";
         }
-        private async ValueTask CreateContainer(int redisHostPort, string redisContainerName)
-        {
-            // create the container
-            await Client.Containers.CreateContainerAsync(new CreateContainerParameters
-            {
-                Image = RedisImageName,
-                Name = redisContainerName,
-                Tty = true,
-                ExposedPorts = new Dictionary<string, EmptyStruct> { { "6379/tcp", new EmptyStruct() } },
-                HostConfig = new HostConfig
-                {
-                    PortBindings = new Dictionary<string, IList<PortBinding>>
-                    {
-                        {
-                            "6379/tcp", new List<PortBinding> {new PortBinding {HostPort = $"{redisHostPort}"}}
-                        }
-                    }
-                }
-            });
 
-
-            // start the container
-            await Client.Containers.StartContainerAsync(redisContainerName, new ContainerStartParameters());
-
-            // Provide a 30 second startup delay
-            await Task.Delay(TimeSpan.FromSeconds(10));
-        }
         public async ValueTask DisposeAsync()
         {
-            if (Client != null)
-            {
-                // Delay to make sure that all tests has completed cleanup.
-                await Task.Delay(TimeSpan.FromSeconds(5));
-                await KillContainer(RedisContainerName);
-                await KillContainer(RedisContainerName2);
-               
-                Client.Dispose();
-            }
-        }
-        private async ValueTask KillContainer(string container)
-        {
-            // Kill the container, we can't simply stop the container because Redis can hung indefinetly
-            // if we simply stop the container.
-            await Client.Containers.KillContainerAsync(container, new ContainerKillParameters());
-
-            await Client.Containers.RemoveContainerAsync(container,
-                new ContainerRemoveParameters { Force = true });
+            await Task.WhenAll(
+                _container1.DisposeAsync().AsTask(),
+                _container2.DisposeAsync().AsTask());
         }
     }
 }


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `Docker.DotNet` fixtures across the test and benchmark projects with `Testcontainers` and `Testcontainers.Redis`. No production code changes.

The new fixtures:

* Auto-detect the Docker socket across Linux, macOS, Windows, Rancher Desktop, Colima, and Podman. The previous fixtures threw `NotSupportedException` on macOS.
* Replace the hard-coded 10-second startup `Task.Delay` with proper readiness probes — Redis `PING` for the single-node fixture, `"Cluster state changed: ok"` log-message probe for `grokzen/redis-cluster`. Cluster test setup now completes in ~4 seconds instead of always paying ~10s.
* Drop the manual `KillContainer` / `RemoveContainer` cleanup logic; Testcontainers + Ryuk reaps containers automatically, including after a test crash.

Net diff: +71 / -413 lines.

## Test plan

- [x] `dotnet build -c Release` clean (0 errors).
- [x] `dotnet test src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj -c Release` — 109 passed, 0 failed.
- [x] `dotnet test src/Akka.Persistence.Redis.Cluster.Tests/Akka.Persistence.Redis.Cluster.Tests.csproj -c Release` — 89 passed, 0 failed.
- [x] Both benchmark projects build clean.
- [x] No remaining `Docker.DotNet` / `DockerClientConfiguration` references in `src/`.