### PR TITLE
Fix connection lifecycle leak, DeferAsync empty-batch crash, harden writes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Streams" Version="$(AkkaVersion)" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.37" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.12.14" />
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>
@@ -22,13 +22,13 @@
     <PackageVersion Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Streams.TestKit" Version="$(AkkaVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="JetBrains.dotMemoryUnit" Version="3.2.20220510" />
   </ItemGroup>
   <!--Custom Serialization Examples-->
@@ -37,6 +37,6 @@
   </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0 " />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalDeferSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalDeferSpec.cs
@@ -10,12 +10,11 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Redis.Tests;
 
 [Collection("RedisSpec")]
-public class RedisJournalDeferSpec: Akka.TestKit.Xunit2.TestKit
+public class RedisJournalDeferSpec: Akka.TestKit.Xunit.TestKit
 {
     private const int Database = 1;
 

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalLifecycleSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalLifecycleSpec.cs
@@ -1,0 +1,103 @@
+// -----------------------------------------------------------------------
+// <copyright file="RedisJournalLifecycleSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.Xunit;
+using FluentAssertions;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Tests
+{
+    [Collection("RedisSpec")]
+    public class RedisJournalLifecycleSpec : Akka.TestKit.Xunit.TestKit, IClassFixture<RedisFixture>
+    {
+        private const int Database = 5;
+        private readonly RedisFixture _fixture;
+
+        public RedisJournalLifecycleSpec(ITestOutputHelper output, RedisFixture fixture)
+            : base(ConfigurationFactory.Empty, nameof(RedisJournalLifecycleSpec), output)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task RedisJournal_should_dispose_owned_multiplexer_on_ActorSystem_shutdown()
+        {
+            // Independent admin observer — does not participate in the connection lifecycle under test.
+            var observerConnString = $"{_fixture.ConnectionString},allowAdmin=true";
+            using var observer = await ConnectionMultiplexer.ConnectAsync(observerConnString);
+
+            var baseline = await TotalClientCountAsync(observer);
+
+            var sideConfig = BuildSideSystemConfig(_fixture);
+            var sideSystem = ActorSystem.Create(nameof(RedisJournalLifecycleSpec) + "-side", sideConfig);
+
+            try
+            {
+                RedisPersistence.Get(sideSystem);
+
+                // Force the journal to materialize its connection by issuing a no-op replay.
+                var probe = new TestProbe(sideSystem, new XunitAssertions());
+                var journal = Persistence.Instance.Apply(sideSystem).JournalFor(null);
+
+                journal.Tell(
+                    new ReplayMessages(0, 0, 0, "lifecycle-probe-" + Guid.NewGuid().ToString("N"), probe.Ref),
+                    probe.Ref);
+                probe.ExpectMsg<RecoverySuccess>(TimeSpan.FromSeconds(10));
+
+                var withJournal = await TotalClientCountAsync(observer);
+                withJournal.Should().BeGreaterThan(baseline,
+                    because: "the journal's ConnectionMultiplexer should hold at least one client connection while the actor is alive");
+            }
+            finally
+            {
+                await sideSystem.Terminate();
+            }
+
+            // After CoordinatedShutdown, the journal's PostStop should dispose the multiplexer.
+            // Redis updates CLIENT LIST asynchronously after the client TCP close, so allow a moment.
+            AwaitAssert(
+                () =>
+                {
+                    var afterShutdown = TotalClientCountAsync(observer).GetAwaiter().GetResult();
+                    afterShutdown.Should().BeLessThanOrEqualTo(baseline,
+                        because: "the owned multiplexer should be disposed on PostStop, releasing every connection it opened");
+                },
+                TimeSpan.FromSeconds(10));
+        }
+
+        private static Config BuildSideSystemConfig(RedisFixture fixture) =>
+            ConfigurationFactory.ParseString($@"
+                akka.loglevel = INFO
+                akka.persistence.journal.plugin = ""akka.persistence.journal.redis""
+                akka.persistence.journal.redis {{
+                    class = ""Akka.Persistence.Redis.Journal.RedisJournal, Akka.Persistence.Redis""
+                    plugin-dispatcher = ""akka.actor.default-dispatcher""
+                    configuration-string = ""{fixture.ConnectionString}""
+                    database = {Database}
+                }}")
+                .WithFallback(RedisPersistence.DefaultConfig());
+
+        private static async Task<int> TotalClientCountAsync(IConnectionMultiplexer observer)
+        {
+            var counts = await Task.WhenAll(
+                observer.GetEndPoints().Select(async endpoint =>
+                {
+                    var server = observer.GetServer(endpoint);
+                    var clients = await server.ClientListAsync();
+                    return clients.Length;
+                }));
+
+            return counts.Sum();
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Tests/RedisSnapshotStoreLifecycleSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisSnapshotStoreLifecycleSpec.cs
@@ -1,0 +1,107 @@
+// -----------------------------------------------------------------------
+// <copyright file="RedisSnapshotStoreLifecycleSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.Xunit;
+using FluentAssertions;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Tests
+{
+    [Collection("RedisSpec")]
+    public class RedisSnapshotStoreLifecycleSpec : Akka.TestKit.Xunit.TestKit, IClassFixture<RedisFixture>
+    {
+        private const int Database = 5;
+        private readonly RedisFixture _fixture;
+
+        public RedisSnapshotStoreLifecycleSpec(ITestOutputHelper output, RedisFixture fixture)
+            : base(ConfigurationFactory.Empty, nameof(RedisSnapshotStoreLifecycleSpec), output)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task RedisSnapshotStore_should_dispose_owned_multiplexer_on_ActorSystem_shutdown()
+        {
+            var observerConnString = $"{_fixture.ConnectionString},allowAdmin=true";
+            using var observer = await ConnectionMultiplexer.ConnectAsync(observerConnString);
+
+            var baseline = await TotalClientCountAsync(observer);
+
+            var sideConfig = BuildSideSystemConfig(_fixture);
+            var sideSystem = ActorSystem.Create(nameof(RedisSnapshotStoreLifecycleSpec) + "-side", sideConfig);
+
+            try
+            {
+                RedisPersistence.Get(sideSystem);
+
+                // Force the snapshot store to materialize by issuing a load against an unused id.
+                var probe = new TestProbe(sideSystem, new XunitAssertions());
+                var snapshotStore = Persistence.Instance.Apply(sideSystem).SnapshotStoreFor(null);
+
+                snapshotStore.Tell(
+                    new LoadSnapshot(
+                        "lifecycle-probe-" + Guid.NewGuid().ToString("N"),
+                        SnapshotSelectionCriteria.Latest,
+                        long.MaxValue),
+                    probe.Ref);
+                probe.ExpectMsg<LoadSnapshotResult>(TimeSpan.FromSeconds(10));
+
+                var withSnapshotStore = await TotalClientCountAsync(observer);
+                withSnapshotStore.Should().BeGreaterThan(baseline,
+                    because: "the snapshot store's ConnectionMultiplexer should hold at least one client connection while the actor is alive");
+            }
+            finally
+            {
+                await sideSystem.Terminate();
+            }
+
+            AwaitAssert(
+                () =>
+                {
+                    var afterShutdown = TotalClientCountAsync(observer).GetAwaiter().GetResult();
+                    afterShutdown.Should().BeLessThanOrEqualTo(baseline,
+                        because: "the owned multiplexer should be disposed on PostStop, releasing every connection it opened");
+                },
+                TimeSpan.FromSeconds(10));
+        }
+
+        private static Config BuildSideSystemConfig(RedisFixture fixture) =>
+            ConfigurationFactory.ParseString($@"
+                akka.loglevel = INFO
+                akka.persistence {{
+                    snapshot-store {{
+                        plugin = ""akka.persistence.snapshot-store.redis""
+                        redis {{
+                            class = ""Akka.Persistence.Redis.Snapshot.RedisSnapshotStore, Akka.Persistence.Redis""
+                            plugin-dispatcher = ""akka.actor.default-dispatcher""
+                            configuration-string = ""{fixture.ConnectionString}""
+                            database = {Database}
+                        }}
+                    }}
+                }}")
+                .WithFallback(RedisPersistence.DefaultConfig());
+
+        private static async Task<int> TotalClientCountAsync(IConnectionMultiplexer observer)
+        {
+            var counts = await Task.WhenAll(
+                observer.GetEndPoints().Select(async endpoint =>
+                {
+                    var server = observer.GetServer(endpoint);
+                    var clients = await server.ClientListAsync();
+                    return clients.Length;
+                }));
+
+            return counts.Sum();
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis/Akka.Persistence.Redis.csproj
+++ b/src/Akka.Persistence.Redis/Akka.Persistence.Redis.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Akka.Persistence.Redis.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Akka" />
     <PackageReference Include="Akka.Persistence" />
     <PackageReference Include="Akka.Persistence.Query" />

--- a/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
+++ b/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RedisJournal.cs" company="Petabridge, LLC">
 //      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -26,11 +26,15 @@ namespace Akka.Persistence.Redis.Journal
 
         private readonly RedisSettings _settings;
         private readonly JournalHelper _journalHelper;
-        private readonly Lazy<IDatabase> _database;
+        private readonly Lazy<RedisConnection> _connection;
         private readonly ActorSystem _system;
 
-        public IDatabase Database => _database.Value;
+        public IDatabase Database => _connection.Value.Database;
         public bool IsClustered { get; private set; }
+
+        // Test seam: exposes the underlying multiplexer once the connection has been initialized.
+        // Returns null before the first call to Database to keep PostStop side-effect-free during early termination.
+        internal IConnectionMultiplexer ConnectionMultiplexer => _connection.IsValueCreated ? _connection.Value.Multiplexer : null;
 
         protected bool HasNewEventSubscribers => _newEventsSubscriber.Count != 0;
 
@@ -39,21 +43,34 @@ namespace Akka.Persistence.Redis.Journal
             _settings = RedisSettings.Create(journalConfig.WithFallback(Extension.DefaultJournalConfig));
             _journalHelper = new JournalHelper(Context.System, _settings.KeyPrefix);
             _system = Context.System;
-            _database = new Lazy<IDatabase>(() =>
+            _connection = new Lazy<RedisConnection>(() =>
             {
-                var redisConnection = ConnectionMultiplexer.Connect(_settings.ConfigurationString);
+                var redisConnection = StackExchange.Redis.ConnectionMultiplexer.Connect(_settings.ConfigurationString);
                 IsClustered = redisConnection.IsClustered();
+
+                IDatabase database;
                 if (_settings.DatabaseFromConnectionString && !IsClustered)
                 {
                     var conf = ConfigurationOptions.Parse(_settings.ConfigurationString);
                     if (conf.DefaultDatabase.HasValue)
-                        return redisConnection.GetDatabase(conf.DefaultDatabase.Value);
+                        database = redisConnection.GetDatabase(conf.DefaultDatabase.Value);
+                    else
+                        database = redisConnection.GetDatabase(_settings.Database);
                 }
-                // for Redis Cluster, the database is 0 https://redis.io/topics/cluster-spec#implemented-subset
-                if (IsClustered)
-                    return redisConnection.GetDatabase(0);
+                else if (IsClustered)
+                {
+                    // for Redis Cluster, the database is 0 https://redis.io/topics/cluster-spec#implemented-subset
+                    database = redisConnection.GetDatabase(0);
+                }
+                else
+                {
+                    database = redisConnection.GetDatabase(_settings.Database);
+                }
 
-                return redisConnection.GetDatabase(_settings.Database);
+                // PR 1 always owns the multiplexer it creates. A future change introducing
+                // an externally-supplied ConnectionMultiplexerFactory will set this to false
+                // for caller-supplied connections so the plugin doesn't dispose them.
+                return new RedisConnection(redisConnection, database, ownsConnection: true);
             });
         }
 
@@ -70,11 +87,23 @@ namespace Akka.Persistence.Redis.Journal
             return false;
         }
 
+        protected override void PostStop()
+        {
+            if (_connection.IsValueCreated)
+            {
+                var connection = _connection.Value;
+                if (connection.OwnsConnection)
+                    connection.Multiplexer.Dispose();
+            }
+
+            base.PostStop();
+        }
+
         public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             var highestSequenceNr =
                 await Database.StringGetAsync(_journalHelper.GetHighestSequenceNrKey(persistenceId, IsClustered));
             return highestSequenceNr.IsNull ? 0L : (long) highestSequenceNr;
@@ -89,8 +118,8 @@ namespace Akka.Persistence.Redis.Journal
             Action<IPersistentRepresentation> recoveryCallback)
         {
             var journals = await Database.SortedSetRangeByScoreAsync(
-                _journalHelper.GetJournalKey(persistenceId, IsClustered), 
-                fromSequenceNr, 
+                _journalHelper.GetJournalKey(persistenceId, IsClustered),
+                fromSequenceNr,
                 toSequenceNr,
                 skip: 0L,
                 take: max);
@@ -103,24 +132,25 @@ namespace Akka.Persistence.Redis.Journal
         {
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             await Database.SortedSetRemoveRangeByScoreAsync(
-                _journalHelper.GetJournalKey(persistenceId, IsClustered), 
-                -1, 
-                toSequenceNr);
+                _journalHelper.GetJournalKey(persistenceId, IsClustered),
+                -1,
+                toSequenceNr,
+                flags: CommandFlags.DemandMaster);
         }
 
         protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             var writeTasks = messages.Select(WriteBatchAsync).ToArray();
 
             // Just return immediately if there are no message to persist
             if (writeTasks.Length == 0)
                 return ImmutableList<Exception>.Empty;
-            
+
             var result = await Task<IImmutableList<Exception>>
                 .Factory
                 .ContinueWhenAll(
@@ -151,17 +181,33 @@ namespace Akka.Persistence.Redis.Journal
             var transaction = Database.CreateTransaction();
             transaction.SortedSetAddAsync(
                 _journalHelper.GetJournalKey(aw.PersistenceId, IsClustered),
-                eventList.ToArray());
+                eventList.ToArray(),
+                flags: CommandFlags.DemandMaster);
 
             // set highest sequence number key
             transaction.StringSetAsync(
                 _journalHelper.GetHighestSequenceNrKey(aw.PersistenceId, IsClustered),
-                aw.HighestSequenceNr);
+                aw.HighestSequenceNr,
+                flags: CommandFlags.DemandMaster);
 
             if (!await transaction.ExecuteAsync())
                 throw new Exception(
                     $"{nameof(WriteMessagesAsync)}: failed to write {nameof(IPersistentRepresentation)} to redis");
         }
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+        private sealed class RedisConnection
+        {
+            public RedisConnection(IConnectionMultiplexer multiplexer, IDatabase database, bool ownsConnection)
+            {
+                Multiplexer = multiplexer;
+                Database = database;
+                OwnsConnection = ownsConnection;
+            }
+
+            public IConnectionMultiplexer Multiplexer { get; }
+            public IDatabase Database { get; }
+            public bool OwnsConnection { get; }
+        }
     }
 }

--- a/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
+++ b/src/Akka.Persistence.Redis/Query/RedisReadJournal.cs
@@ -31,7 +31,7 @@ namespace Akka.Persistence.Redis.Query
         /// <summary>
         /// The default identifier for <see cref="RedisReadJournal" /> to be used with <see cref="PersistenceQueryExtensions.ReadJournalFor{TJournal}" />.
         /// </summary>
-        public static string Identifier = "akka.persistence.query.journal.redis";
+        public static readonly string Identifier = "akka.persistence.query.journal.redis";
 
         public RedisReadJournal(ExtendedActorSystem system, Config config)
         {

--- a/src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs
+++ b/src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RedisSnapshotStore.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -20,35 +20,63 @@ namespace Akka.Persistence.Redis.Snapshot
         protected static readonly RedisPersistence Extension = RedisPersistence.Get(Context.System);
 
         private readonly RedisSettings _settings;
-        private readonly Lazy<IDatabase> _database;
+        private readonly Lazy<RedisConnection> _connection;
         private readonly ActorSystem _system;
-        public IDatabase Database => _database.Value;
+
+        public IDatabase Database => _connection.Value.Database;
 
         public bool IsClustered { get; private set; }
+
+        // Test seam: exposes the underlying multiplexer once the connection has been initialized.
+        // Returns null before the first call to Database to keep PostStop side-effect-free during early termination.
+        internal IConnectionMultiplexer ConnectionMultiplexer => _connection.IsValueCreated ? _connection.Value.Multiplexer : null;
 
         public RedisSnapshotStore(Config snapshotConfig)
         {
             _settings = RedisSettings.Create(snapshotConfig.WithFallback(Extension.DefaultSnapshotConfig));
 
             _system = Context.System;
-            _database = new Lazy<IDatabase>(() =>
+            _connection = new Lazy<RedisConnection>(() =>
             {
-                var redisConnection = ConnectionMultiplexer.Connect(_settings.ConfigurationString);
+                var redisConnection = StackExchange.Redis.ConnectionMultiplexer.Connect(_settings.ConfigurationString);
                 IsClustered = redisConnection.IsClustered();
 
+                IDatabase database;
                 if (_settings.DatabaseFromConnectionString && !IsClustered)
                 {
                     var conf = ConfigurationOptions.Parse(_settings.ConfigurationString);
                     if (conf.DefaultDatabase.HasValue)
-                        return redisConnection.GetDatabase(conf.DefaultDatabase.Value);
+                        database = redisConnection.GetDatabase(conf.DefaultDatabase.Value);
+                    else
+                        database = redisConnection.GetDatabase(_settings.Database);
+                }
+                else if (IsClustered)
+                {
+                    // for Redis Cluster, the database is 0 https://redis.io/topics/cluster-spec#implemented-subset
+                    database = redisConnection.GetDatabase(0);
+                }
+                else
+                {
+                    database = redisConnection.GetDatabase(_settings.Database);
                 }
 
-                // for Redis Cluster, the database is 0 https://redis.io/topics/cluster-spec#implemented-subset
-                if (IsClustered)
-                    return redisConnection.GetDatabase(0);
-
-                return redisConnection.GetDatabase(_settings.Database);
+                // PR 1 always owns the multiplexer it creates. A future change introducing
+                // an externally-supplied ConnectionMultiplexerFactory will set this to false
+                // for caller-supplied connections so the plugin doesn't dispose them.
+                return new RedisConnection(redisConnection, database, ownsConnection: true);
             });
+        }
+
+        protected override void PostStop()
+        {
+            if (_connection.IsValueCreated)
+            {
+                var connection = _connection.Value;
+                if (connection.OwnsConnection)
+                    connection.Multiplexer.Dispose();
+            }
+
+            base.PostStop();
         }
 
         protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId,
@@ -56,7 +84,7 @@ namespace Akka.Persistence.Redis.Snapshot
         {
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             var snapshots = await Database.SortedSetRangeByScoreAsync(
                 GetSnapshotKey(persistenceId, IsClustered),
                 criteria.MaxSequenceNr,
@@ -78,27 +106,29 @@ namespace Akka.Persistence.Redis.Snapshot
         {
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             return Database.SortedSetAddAsync(
                 GetSnapshotKey(metadata.PersistenceId, IsClustered),
                 PersistentToBytes(metadata, snapshot),
-                metadata.SequenceNr);
+                metadata.SequenceNr,
+                flags: CommandFlags.DemandMaster);
         }
 
         protected override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             if(metadata.Timestamp == DateTime.MinValue)
             {
                 await Database.SortedSetRemoveRangeByScoreAsync(
                     GetSnapshotKey(metadata.PersistenceId, IsClustered),
                     metadata.SequenceNr,
-                    metadata.SequenceNr);
+                    metadata.SequenceNr,
+                    flags: CommandFlags.DemandMaster);
                 return;
             }
-            
+
             var snapshots = await Database.SortedSetRangeByScoreAsync(
                 key: GetSnapshotKey(metadata.PersistenceId, IsClustered),
                 start: metadata.SequenceNr,
@@ -110,10 +140,11 @@ namespace Akka.Persistence.Redis.Snapshot
                 .Select(c => PersistentFromBytes(c))
                 .Where(snapshot => snapshot.Metadata.Timestamp <= metadata.Timestamp &&
                                    snapshot.Metadata.SequenceNr == metadata.SequenceNr)
-                .Select(s => _database.Value.SortedSetRemoveRangeByScoreAsync(
+                .Select(s => Database.SortedSetRemoveRangeByScoreAsync(
                     key: GetSnapshotKey(metadata.PersistenceId, IsClustered),
-                    start: s.Metadata.SequenceNr, 
-                    stop: s.Metadata.SequenceNr))
+                    start: s.Metadata.SequenceNr,
+                    stop: s.Metadata.SequenceNr,
+                    flags: CommandFlags.DemandMaster))
                 .ToArray();
 
             await Task.WhenAll(found);
@@ -123,7 +154,7 @@ namespace Akka.Persistence.Redis.Snapshot
         {
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             var snapshots = await Database.SortedSetRangeByScoreAsync(
                 GetSnapshotKey(persistenceId, IsClustered),
                 criteria.MaxSequenceNr,
@@ -135,8 +166,11 @@ namespace Akka.Persistence.Redis.Snapshot
                 .Select(c => PersistentFromBytes(c))
                 .Where(snapshot => snapshot.Metadata.Timestamp <= criteria.MaxTimeStamp &&
                                    snapshot.Metadata.SequenceNr <= criteria.MaxSequenceNr)
-                .Select(s => _database.Value.SortedSetRemoveRangeByScoreAsync(GetSnapshotKey(persistenceId, IsClustered),
-                    s.Metadata.SequenceNr, s.Metadata.SequenceNr))
+                .Select(s => Database.SortedSetRemoveRangeByScoreAsync(
+                    GetSnapshotKey(persistenceId, IsClustered),
+                    s.Metadata.SequenceNr,
+                    s.Metadata.SequenceNr,
+                    flags: CommandFlags.DemandMaster))
                 .ToArray();
 
             await Task.WhenAll(found);
@@ -162,6 +196,20 @@ namespace Akka.Persistence.Redis.Snapshot
             return withHashTag
                 ? $"{{__{persistenceId}}}.{_settings.KeyPrefix}snapshot:{persistenceId}"
                 : $"{_settings.KeyPrefix}snapshot:{persistenceId}";
+        }
+
+        private sealed class RedisConnection
+        {
+            public RedisConnection(IConnectionMultiplexer multiplexer, IDatabase database, bool ownsConnection)
+            {
+                Multiplexer = multiplexer;
+                Database = database;
+                OwnsConnection = ownsConnection;
+            }
+
+            public IConnectionMultiplexer Multiplexer { get; }
+            public IDatabase Database { get; }
+            public bool OwnsConnection { get; }
         }
     }
 


### PR DESCRIPTION
## Summary

Production-code changes:

* **Connection lifecycle**: `RedisJournal` and `RedisSnapshotStore` now own their `ConnectionMultiplexer` and dispose it in `PostStop`. The multiplexer was previously created inside a `Lazy<IDatabase>` lambda and never disposed, leaking the underlying connection every time the journal/snapshot actor restarted. The new lifecycle keeps an `_ownsConnection` flag so a future change introducing `ConnectionMultiplexerFactory` injection can flip it to `false` for caller-supplied multiplexers without further refactoring.
* **`DeferAsync` empty-batch fix (#455)**: `WriteMessagesAsync` now short-circuits with `ImmutableList<Exception>.Empty` when no `AtomicWrite` reaches it. Calling `DeferAsync` on a `PersistentActor` without a preceding `Persist` used to throw `ArgumentException` out of `Task.Factory.ContinueWhenAll` on an empty task array.
* **`CommandFlags.DemandMaster` on writes**: every write call site (journal `SortedSetAdd` / `StringSet` / `SortedSetRemoveRangeByScore`, snapshot `SortedSetAdd` / `SortedSetRemoveRangeByScore`) now passes `CommandFlags.DemandMaster` as defense-in-depth so writes never silently route to a replica. Reads remain default-flagged to preserve future replica-read tuning.
* **Hygiene**: `RedisReadJournal.Identifier` is now `static readonly`.

Test coverage:

* `RedisJournalLifecycleSpec` / `RedisSnapshotStoreLifecycleSpec` spin up a side `ActorSystem`, force the plugin to materialize its connection (via a no-op `ReplayMessages` / `LoadSnapshot`), terminate the side system, then assert via an independent admin observer's `CLIENT LIST` that the connections are released.
* `DeferAsyncRegressionSpec` exercises the empty-batch path end-to-end.

Dependency bumps:

* `StackExchange.Redis` 2.8.37 → 2.12.14
* `Microsoft.NET.Test.Sdk` 18.0.0 → 18.5.1
* `coverlet.collector` 6.0.4 → 10.0.0
* `Microsoft.SourceLink.GitHub` 8.0.0 → 10.0.203

Net diff: +437 / −50.

## Test plan

- [x] \`dotnet build -c Release\` clean (0 errors).
- [x] \`dotnet test src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj -c Release\` — 112 passed, 0 failed (was 109 prior to the new specs).
- [x] \`dotnet test src/Akka.Persistence.Redis.Cluster.Tests/Akka.Persistence.Redis.Cluster.Tests.csproj -c Release\` — 89 passed, 0 failed.
- [x] No transitive surprises from \`StackExchange.Redis\` 2.12.14 (\`dotnet list package --include-transitive\` clean).