### PR TITLE
Make CI fail on test failures and harden cluster fixture readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,12 @@ akka.actor {
   }
 }
 ```
+
+## Running the tests locally
+
+The test suites stand up Redis via [Testcontainers for .NET](https://dotnet.testcontainers.org/), so a working Docker host is required (Docker Desktop, Rancher Desktop, Colima, or Podman all work — Testcontainers auto-detects the socket).
+
+* `Akka.Persistence.Redis.Tests` spins up two `redis:latest` containers and connects to them through a comma-separated host list, exercising the standalone-Redis code paths.
+* `Akka.Persistence.Redis.Cluster.Tests` runs the cluster suite against the [`grokzen/redis-cluster:6.0.13`](https://hub.docker.com/r/grokzen/redis-cluster) image. **The image is one Docker container running six `redis-server` processes under supervisord** — three masters + three replicas, on consecutive ports starting from a randomly-chosen base port. The fixture publishes those six ports 1:1 to the host so the cluster's gossiped node addresses match what the SE.Redis client connects to, then probes `CLUSTER INFO` on every endpoint until each node reports `cluster_state:ok` with full 16384-slot coverage before any test runs.
+
+  One implication of the single-container topology: integration tests cannot trigger a real per-node failover by stopping a Docker container, because killing the container kills the whole cluster. Anything that needs to exercise a single primary failover today has to either `docker exec` into the container and signal one of the redis processes (or `supervisorctl stop redis-N`), or use `IServer.Shutdown(...)` against a specific endpoint. A multi-container cluster fixture is the longer-term answer when richer failover coverage is required.

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -45,24 +45,28 @@ jobs:
         continueOnError: false
 
       - pwsh: |
+          $exitCode = 0
           Get-ChildItem `
             -Recurse `
             -File `
             -Include '*.Tests.csproj' `
             -Exclude '*examples*', '*benchmarks*' `
-          | ForEach-Object { `
-            dotnet test -c Release --no-build --logger:trx --collect:"XPlat Code Coverage" --results-directory TestResults --settings coverlet.runsettings $_.FullName `
+          | ForEach-Object {
+            dotnet test -c Release --no-build --logger:trx --collect:"XPlat Code Coverage" --results-directory TestResults --settings coverlet.runsettings $_.FullName
+            if ($LASTEXITCODE -ne 0) { $exitCode = $LASTEXITCODE }
           }
+          exit $exitCode
         displayName: 'Run tests'
-        continueOnError: true # Allow continuation even if tests fail
+        # No continueOnError: any failing project bubbles a non-zero exit code from the loop and fails the job.
 
       - task: PublishTestResults@2
+        condition: always()  # publish .trx results even when the test step failed
         inputs:
           testResultsFormat: VSTest
           testResultsFiles: '**/*.trx' #TestResults folder usually
           testRunTitle: ${{ parameters.name }}
           mergeTestResults: true
-          failTaskOnFailedTests: false
+          failTaskOnFailedTests: true
           publishRunAttachments: true
           
       - pwsh: |
@@ -101,8 +105,3 @@ jobs:
           PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
           ArtifactName: 'nuget'
           publishLocation: 'Container'
-
-      - script: 'echo 1>&2'
-        failOnStderr: true
-        displayName: 'If above is partially succeeded, then fail'
-        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')

--- a/src/Akka.Persistence.Redis.Cluster.Tests/RedisClusterFixture.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Tests/RedisClusterFixture.cs
@@ -4,10 +4,15 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+#nullable enable
+
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Akka.Util;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Akka.Persistence.Redis.Cluster.Tests
@@ -31,8 +36,7 @@ namespace Akka.Persistence.Redis.Cluster.Tests
         {
             var builder = new ContainerBuilder("grokzen/redis-cluster:6.0.13")
                 .WithEnvironment("IP", "0.0.0.0")
-                .WithEnvironment("INITIAL_PORT", _basePort.ToString())
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Cluster state changed: ok"));
+                .WithEnvironment("INITIAL_PORT", _basePort.ToString());
 
             for (var offset = 0; offset < 6; offset++)
             {
@@ -41,16 +45,76 @@ namespace Akka.Persistence.Redis.Cluster.Tests
             }
 
             _container = builder.Build();
-
             await _container.StartAsync();
 
             ConnectionString = $"127.0.0.1:{_basePort}";
+
+            // The 6-node cluster bootstraps asynchronously after the container starts. The
+            // per-node "Cluster state changed: ok" log line fires for whichever node settles
+            // first - waiting on it via Testcontainers' first-match log probe lets tests
+            // start while the other nodes are still gossiping and the slot map is still in
+            // flight. Probe the cluster directly until every slot is assigned and ok.
+            await WaitForClusterReadyAsync(TimeSpan.FromSeconds(60));
         }
 
         public async ValueTask DisposeAsync()
         {
             if (_container is not null)
                 await _container.DisposeAsync();
+        }
+
+        private async Task WaitForClusterReadyAsync(TimeSpan timeout)
+        {
+            // Probe via the CLUSTER INFO command, which is part of the cluster command suite
+            // and does not require allowAdmin. The probe stays inside this fixture; production
+            // connection strings are unaffected.
+            var probeConnectionString = $"{ConnectionString},abortConnect=false,connectRetry=5,connectTimeout=2000";
+            var deadline = DateTime.UtcNow + timeout;
+            Exception? lastError = null;
+
+            while (DateTime.UtcNow < deadline)
+            {
+                try
+                {
+                    using var probe = await ConnectionMultiplexer.ConnectAsync(probeConnectionString);
+                    var server = probe.GetServer(probe.GetEndPoints().First());
+                    var result = await server.ExecuteAsync("CLUSTER", "INFO");
+                    var kv = ParseClusterInfo(result.ToString());
+
+                    if (kv.TryGetValue("cluster_state", out var state) && state == "ok"
+                        && kv.TryGetValue("cluster_slots_assigned", out var assigned) && assigned == "16384"
+                        && kv.TryGetValue("cluster_slots_ok", out var slotsOk) && slotsOk == "16384")
+                    {
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lastError = ex;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+            }
+
+            throw new TimeoutException(
+                $"Redis cluster at {ConnectionString} did not become healthy within {timeout}.",
+                lastError);
+        }
+
+        private static System.Collections.Generic.Dictionary<string, string> ParseClusterInfo(string raw)
+        {
+            var kv = new System.Collections.Generic.Dictionary<string, string>(StringComparer.Ordinal);
+            if (string.IsNullOrEmpty(raw))
+                return kv;
+
+            foreach (var line in raw.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var sep = line.IndexOf(':');
+                if (sep <= 0) continue;
+                kv[line.Substring(0, sep)] = line.Substring(sep + 1);
+            }
+
+            return kv;
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Cluster.Tests/RedisClusterFixture.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Tests/RedisClusterFixture.cs
@@ -49,12 +49,12 @@ namespace Akka.Persistence.Redis.Cluster.Tests
 
             ConnectionString = $"127.0.0.1:{_basePort}";
 
-            // The 6-node cluster bootstraps asynchronously after the container starts. The
-            // per-node "Cluster state changed: ok" log line fires for whichever node settles
-            // first - waiting on it via Testcontainers' first-match log probe lets tests
-            // start while the other nodes are still gossiping and the slot map is still in
-            // flight. Probe the cluster directly until every slot is assigned and ok.
-            await WaitForClusterReadyAsync(TimeSpan.FromSeconds(60));
+            // The 6-node cluster bootstraps asynchronously after the container starts.
+            // Each Redis node computes cluster_state from its own view; a single node
+            // returning "ok" while a peer still has the cluster marked FAIL is enough to
+            // surface CLUSTERDOWN to the journal during its first command. Wait until
+            // every node we know about reports cluster_state:ok with full slot coverage.
+            await WaitForClusterReadyAsync(TimeSpan.FromSeconds(90));
         }
 
         public async ValueTask DisposeAsync()
@@ -71,33 +71,57 @@ namespace Akka.Persistence.Redis.Cluster.Tests
             var probeConnectionString = $"{ConnectionString},abortConnect=false,connectRetry=5,connectTimeout=2000";
             var deadline = DateTime.UtcNow + timeout;
             Exception? lastError = null;
+            string? lastNotReadyReason = null;
 
             while (DateTime.UtcNow < deadline)
             {
                 try
                 {
                     using var probe = await ConnectionMultiplexer.ConnectAsync(probeConnectionString);
-                    var server = probe.GetServer(probe.GetEndPoints().First());
-                    var result = await server.ExecuteAsync("CLUSTER", "INFO");
-                    var kv = ParseClusterInfo(result.ToString());
+                    var endpoints = probe.GetEndPoints();
 
-                    if (kv.TryGetValue("cluster_state", out var state) && state == "ok"
-                        && kv.TryGetValue("cluster_slots_assigned", out var assigned) && assigned == "16384"
-                        && kv.TryGetValue("cluster_slots_ok", out var slotsOk) && slotsOk == "16384")
+                    // SE.Redis discovers topology after connect; until it has found all 6
+                    // grokzen nodes, retry rather than declare ready.
+                    if (endpoints.Length < 6)
                     {
-                        return;
+                        lastNotReadyReason = $"only {endpoints.Length}/6 endpoints discovered";
+                    }
+                    else
+                    {
+                        var allHealthy = true;
+                        foreach (var endpoint in endpoints)
+                        {
+                            var server = probe.GetServer(endpoint);
+                            var result = await server.ExecuteAsync("CLUSTER", "INFO");
+                            var kv = ParseClusterInfo(result.ToString());
+                            kv.TryGetValue("cluster_state", out var state);
+                            kv.TryGetValue("cluster_slots_assigned", out var assigned);
+                            kv.TryGetValue("cluster_slots_ok", out var slotsOk);
+
+                            if (state != "ok" || assigned != "16384" || slotsOk != "16384")
+                            {
+                                allHealthy = false;
+                                lastNotReadyReason = $"endpoint {endpoint} reports cluster_state={state ?? "?"} slots_assigned={assigned ?? "?"} slots_ok={slotsOk ?? "?"}";
+                                break;
+                            }
+                        }
+
+                        if (allHealthy)
+                            return;
                     }
                 }
                 catch (Exception ex)
                 {
                     lastError = ex;
+                    lastNotReadyReason = ex.Message;
                 }
 
                 await Task.Delay(TimeSpan.FromMilliseconds(250));
             }
 
+            var detail = lastNotReadyReason ?? "no probe attempted";
             throw new TimeoutException(
-                $"Redis cluster at {ConnectionString} did not become healthy within {timeout}.",
+                $"Redis cluster at {ConnectionString} did not become healthy within {timeout}. Last status: {detail}.",
                 lastError);
         }
 

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalDeferSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalDeferSpec.cs
@@ -10,12 +10,11 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Redis.Tests;
 
 [Collection("RedisSpec")]
-public class RedisJournalDeferSpec: Akka.TestKit.Xunit2.TestKit
+public class RedisJournalDeferSpec: Akka.TestKit.Xunit.TestKit
 {
     private const int Database = 1;
 

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterFixture.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterFixture.cs
@@ -4,10 +4,15 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+#nullable enable
+
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Akka.Util;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Akka.Persistence.Redis.Cluster.Tests
@@ -31,8 +36,7 @@ namespace Akka.Persistence.Redis.Cluster.Tests
         {
             var builder = new ContainerBuilder("grokzen/redis-cluster:6.0.13")
                 .WithEnvironment("IP", "0.0.0.0")
-                .WithEnvironment("INITIAL_PORT", _basePort.ToString())
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Cluster state changed: ok"));
+                .WithEnvironment("INITIAL_PORT", _basePort.ToString());
 
             for (var offset = 0; offset < 6; offset++)
             {
@@ -41,16 +45,76 @@ namespace Akka.Persistence.Redis.Cluster.Tests
             }
 
             _container = builder.Build();
-
             await _container.StartAsync();
 
             ConnectionString = $"127.0.0.1:{_basePort}";
+
+            // The 6-node cluster bootstraps asynchronously after the container starts. The
+            // per-node "Cluster state changed: ok" log line fires for whichever node settles
+            // first - waiting on it via Testcontainers' first-match log probe lets tests
+            // start while the other nodes are still gossiping and the slot map is still in
+            // flight. Probe the cluster directly until every slot is assigned and ok.
+            await WaitForClusterReadyAsync(TimeSpan.FromSeconds(60));
         }
 
         public async ValueTask DisposeAsync()
         {
             if (_container is not null)
                 await _container.DisposeAsync();
+        }
+
+        private async Task WaitForClusterReadyAsync(TimeSpan timeout)
+        {
+            // Probe via the CLUSTER INFO command, which is part of the cluster command suite
+            // and does not require allowAdmin. The probe stays inside this fixture; production
+            // connection strings are unaffected.
+            var probeConnectionString = $"{ConnectionString},abortConnect=false,connectRetry=5,connectTimeout=2000";
+            var deadline = DateTime.UtcNow + timeout;
+            Exception? lastError = null;
+
+            while (DateTime.UtcNow < deadline)
+            {
+                try
+                {
+                    using var probe = await ConnectionMultiplexer.ConnectAsync(probeConnectionString);
+                    var server = probe.GetServer(probe.GetEndPoints().First());
+                    var result = await server.ExecuteAsync("CLUSTER", "INFO");
+                    var kv = ParseClusterInfo(result.ToString());
+
+                    if (kv.TryGetValue("cluster_state", out var state) && state == "ok"
+                        && kv.TryGetValue("cluster_slots_assigned", out var assigned) && assigned == "16384"
+                        && kv.TryGetValue("cluster_slots_ok", out var slotsOk) && slotsOk == "16384")
+                    {
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lastError = ex;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+            }
+
+            throw new TimeoutException(
+                $"Redis cluster at {ConnectionString} did not become healthy within {timeout}.",
+                lastError);
+        }
+
+        private static System.Collections.Generic.Dictionary<string, string> ParseClusterInfo(string raw)
+        {
+            var kv = new System.Collections.Generic.Dictionary<string, string>(StringComparer.Ordinal);
+            if (string.IsNullOrEmpty(raw))
+                return kv;
+
+            foreach (var line in raw.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var sep = line.IndexOf(':');
+                if (sep <= 0) continue;
+                kv[line.Substring(0, sep)] = line.Substring(sep + 1);
+            }
+
+            return kv;
         }
     }
 }

--- a/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterFixture.cs
+++ b/src/benchmarks/Akka.Persistence.Redis.Tests.Perf/RedisClusterFixture.cs
@@ -49,12 +49,12 @@ namespace Akka.Persistence.Redis.Cluster.Tests
 
             ConnectionString = $"127.0.0.1:{_basePort}";
 
-            // The 6-node cluster bootstraps asynchronously after the container starts. The
-            // per-node "Cluster state changed: ok" log line fires for whichever node settles
-            // first - waiting on it via Testcontainers' first-match log probe lets tests
-            // start while the other nodes are still gossiping and the slot map is still in
-            // flight. Probe the cluster directly until every slot is assigned and ok.
-            await WaitForClusterReadyAsync(TimeSpan.FromSeconds(60));
+            // The 6-node cluster bootstraps asynchronously after the container starts.
+            // Each Redis node computes cluster_state from its own view; a single node
+            // returning "ok" while a peer still has the cluster marked FAIL is enough to
+            // surface CLUSTERDOWN to the journal during its first command. Wait until
+            // every node we know about reports cluster_state:ok with full slot coverage.
+            await WaitForClusterReadyAsync(TimeSpan.FromSeconds(90));
         }
 
         public async ValueTask DisposeAsync()
@@ -71,33 +71,57 @@ namespace Akka.Persistence.Redis.Cluster.Tests
             var probeConnectionString = $"{ConnectionString},abortConnect=false,connectRetry=5,connectTimeout=2000";
             var deadline = DateTime.UtcNow + timeout;
             Exception? lastError = null;
+            string? lastNotReadyReason = null;
 
             while (DateTime.UtcNow < deadline)
             {
                 try
                 {
                     using var probe = await ConnectionMultiplexer.ConnectAsync(probeConnectionString);
-                    var server = probe.GetServer(probe.GetEndPoints().First());
-                    var result = await server.ExecuteAsync("CLUSTER", "INFO");
-                    var kv = ParseClusterInfo(result.ToString());
+                    var endpoints = probe.GetEndPoints();
 
-                    if (kv.TryGetValue("cluster_state", out var state) && state == "ok"
-                        && kv.TryGetValue("cluster_slots_assigned", out var assigned) && assigned == "16384"
-                        && kv.TryGetValue("cluster_slots_ok", out var slotsOk) && slotsOk == "16384")
+                    // SE.Redis discovers topology after connect; until it has found all 6
+                    // grokzen nodes, retry rather than declare ready.
+                    if (endpoints.Length < 6)
                     {
-                        return;
+                        lastNotReadyReason = $"only {endpoints.Length}/6 endpoints discovered";
+                    }
+                    else
+                    {
+                        var allHealthy = true;
+                        foreach (var endpoint in endpoints)
+                        {
+                            var server = probe.GetServer(endpoint);
+                            var result = await server.ExecuteAsync("CLUSTER", "INFO");
+                            var kv = ParseClusterInfo(result.ToString());
+                            kv.TryGetValue("cluster_state", out var state);
+                            kv.TryGetValue("cluster_slots_assigned", out var assigned);
+                            kv.TryGetValue("cluster_slots_ok", out var slotsOk);
+
+                            if (state != "ok" || assigned != "16384" || slotsOk != "16384")
+                            {
+                                allHealthy = false;
+                                lastNotReadyReason = $"endpoint {endpoint} reports cluster_state={state ?? "?"} slots_assigned={assigned ?? "?"} slots_ok={slotsOk ?? "?"}";
+                                break;
+                            }
+                        }
+
+                        if (allHealthy)
+                            return;
                     }
                 }
                 catch (Exception ex)
                 {
                     lastError = ex;
+                    lastNotReadyReason = ex.Message;
                 }
 
                 await Task.Delay(TimeSpan.FromMilliseconds(250));
             }
 
+            var detail = lastNotReadyReason ?? "no probe attempted";
             throw new TimeoutException(
-                $"Redis cluster at {ConnectionString} did not become healthy within {timeout}.",
+                $"Redis cluster at {ConnectionString} did not become healthy within {timeout}. Last status: {detail}.",
                 lastError);
         }
 


### PR DESCRIPTION
## Summary

Three test-infrastructure fixes that combine to address \"green checkmarks on red builds\":

### 1. Azure pipeline was masking test failures

The 'Run tests' step iterates test projects in a PowerShell \`ForEach-Object\` loop. \`ForEach-Object\` swallows non-zero exit codes from the inner \`dotnet test\` invocations — the script always returned 0 even when individual projects reported failures. \`continueOnError: true\` on the same step plus \`failTaskOnFailedTests: false\` on \`PublishTestResults\` made the masking complete. The trailing \`echo 1>&2\` fallback gated on \`Agent.JobStatus == 'SucceededWithIssues'\` never fired because no upstream step ever reached that state.

This PR:
- Tracks \`\$LASTEXITCODE\` per iteration and exits the script with the worst observed code.
- Drops \`continueOnError: true\` from the test step.
- Flips \`failTaskOnFailedTests\` to \`true\` on \`PublishTestResults\` and adds \`condition: always()\` so the .trx files still publish when tests fail.
- Removes the dead \`SucceededWithIssues\` fallback step.

### 2. Cluster fixture was completing readiness too early

The \`grokzen/redis-cluster:6.0.13\` image bootstraps 6 nodes asynchronously after the container starts. The \`Cluster state changed: ok\` log line fires _per node_; \`UntilMessageIsLogged\` returns on the first match — leaving the slot map and replication still in flight on the other five nodes. Local hardware was fast enough to finish bootstrap before tests started; CI agents were not, producing flakes (e.g. 3-second \`WriteMessagesSuccessful\` timeouts on cluster journal replays).

This PR replaces the log-message wait with an explicit \`CLUSTER INFO\` probe loop that polls until \`cluster_state == ok\`, \`cluster_slots_assigned == 16384\`, and \`cluster_slots_ok == 16384\`. \`CLUSTER INFO\` does not require admin mode, so the probe stays minimal. **Production connection strings and any code consumed by users of this plugin are unaffected** — the probe is contained to the cluster fixture used by \`Akka.Persistence.Redis.Cluster.Tests\` and the perf benchmark project.

### 3. RedisJournalDeferSpec.cs broke dev compilation

\`RedisJournalDeferSpec\` was authored against an earlier xunit.v2 baseline and broke compilation when it merged onto the current xunit.v3 tip (it imports \`Xunit.Abstractions\` and inherits from the retired \`Akka.TestKit.Xunit2.TestKit\`, neither of which exist now). The CI masking above hid this on the spec's own PR validation run. Repaired here.

## Test plan

- [x] \`dotnet build -c Release\` clean (0 errors).
- [x] \`dotnet test src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj -c Release\` — 110 passed, 0 failed.
- [x] \`dotnet test src/Akka.Persistence.Redis.Cluster.Tests/Akka.Persistence.Redis.Cluster.Tests.csproj -c Release\` — 89 passed, 0 failed (cluster setup ~5s end-to-end).
- [x] Anonymization scrub clean (no customer / contributor / fork / incident references).