### PR TITLE
Add ConnectionMultiplexerFactory injection + hosting plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,100 @@ using var host = new HostBuilder()
 await host.RunAsync();
 ```
 
+### Supplying a Pre-Configured `IConnectionMultiplexer`
+
+A plain HOCON connection string is enough for most deployments, but some scenarios need an `IConnectionMultiplexer` that has been authored programmatically: Azure Managed Redis with Entra ID / Managed Identity, Redis Sentinel, a custom `ReconnectRetryPolicy` (e.g. `ExponentialRetry`), a tighter `ConfigCheckSeconds` for clustered Redis, or any other `ConfigurationOptions` knob that does not have a connection-string equivalent.
+
+For these cases, set a `ConnectionMultiplexerFactory` on the journal and/or snapshot options. The factory is a `Func<Task<IConnectionMultiplexer>>` that returns the multiplexer the plugin should use. The plugin treats the returned multiplexer as **caller-owned** — it will not dispose it on actor shutdown. Cache the multiplexer in your factory and dispose it yourself when the application terminates.
+
+```csharp
+// Construct the multiplexer once at app startup with whatever ConfigurationOptions you need.
+var configurationOptions = new ConfigurationOptions
+{
+    EndPoints = { { "your-redis-host", 6380 } },
+    Ssl = true,
+    AbortOnConnectFail = false,
+    ConfigCheckSeconds = 10,
+    ReconnectRetryPolicy = new ExponentialRetry(deltaBackOffMilliseconds: 1000),
+};
+
+// (Azure Managed Redis with Entra ID example)
+await configurationOptions.ConfigureForAzureWithTokenCredentialAsync(new ManagedIdentityCredential());
+
+var multiplexer = await ConnectionMultiplexer.ConnectAsync(configurationOptions);
+
+// Most apps share one multiplexer across journal + snapshot store. Pass the same factory
+// delegate to both options.
+Func<Task<IConnectionMultiplexer>> factory = () => Task.FromResult<IConnectionMultiplexer>(multiplexer);
+
+builder.WithRedisPersistence(
+    journalOptions: new RedisJournalOptions
+    {
+        ConnectionMultiplexerFactory = factory,
+    },
+    snapshotOptions: new RedisSnapshotOptions
+    {
+        ConnectionMultiplexerFactory = factory,
+    });
+```
+
+#### Different Redis backends per plugin
+
+The journal and snapshot store can also point at *different* Redis instances by giving each options object its own factory delegate. This is useful when journal events live on a write-tuned cluster while snapshots live on a separate durable store, or when cluster-sharding regions need different persistence backends, or during a migration cutover where new writes go to one Redis while existing snapshots are still served from another.
+
+```csharp
+var journalMultiplexer  = await ConnectionMultiplexer.ConnectAsync(journalConfigOptions);
+var snapshotMultiplexer = await ConnectionMultiplexer.ConnectAsync(snapshotConfigOptions);
+
+builder.WithRedisPersistence(
+    journalOptions: new RedisJournalOptions
+    {
+        ConnectionMultiplexerFactory = () => Task.FromResult<IConnectionMultiplexer>(journalMultiplexer),
+    },
+    snapshotOptions: new RedisSnapshotOptions
+    {
+        ConnectionMultiplexerFactory = () => Task.FromResult<IConnectionMultiplexer>(snapshotMultiplexer),
+    });
+```
+
+Each plugin instance is identified by its plugin id (the full HOCON path, e.g. `akka.persistence.journal.redis`), and factories are routed to the matching plugin at construction time.
+
+#### How it works under the hood
+
+The hosting extension carries factories through Akka.NET's typed `ActorSystemSetup` container. When `journalOptions.ConnectionMultiplexerFactory` and/or `snapshotOptions.ConnectionMultiplexerFactory` is set, `WithRedisPersistence` adds a `MultiRedisConnectionMultiplexerSetup` to the builder's `Setups` list, with one entry per plugin id. The journal and snapshot store actors read this back via `Context.System.Settings.Setup.Get<MultiRedisConnectionMultiplexerSetup>()` and look up the factory keyed by their own `Self.Path.Name` when they first need to connect. Each `ActorSystem` carries its own setup, so multiple systems in the same process can each have their own factory configurations without interfering.
+
+A simpler `RedisConnectionMultiplexerSetup` (single-factory) is also available. When present, it applies to every Redis plugin instance in the system and takes precedence over `MultiRedisConnectionMultiplexerSetup`. The hosting extension always uses the multi-keyed variant; the single variant is intended for code that bootstraps an `ActorSystem` directly without Akka.Hosting (see below).
+
+#### Without Akka.Hosting
+
+If you bootstrap the `ActorSystem` directly via `ActorSystem.Create(...)`, build the setup yourself and pass it to the system. For one shared multiplexer across all Redis plugins:
+
+```csharp
+var multiplexer = await ConnectionMultiplexer.ConnectAsync(configurationOptions);
+
+var setup = ActorSystemSetup.Create(
+    BootstrapSetup.Create().WithConfig(redisHocon),
+    new RedisConnectionMultiplexerSetup(() => Task.FromResult<IConnectionMultiplexer>(multiplexer)));
+
+var system = ActorSystem.Create("my-system", setup);
+```
+
+For per-plugin factories, use `MultiRedisConnectionMultiplexerSetup` and add an entry per plugin id:
+
+```csharp
+var multi = new MultiRedisConnectionMultiplexerSetup()
+    .AddFactory("akka.persistence.journal.redis",        () => Task.FromResult<IConnectionMultiplexer>(journalMultiplexer))
+    .AddFactory("akka.persistence.snapshot-store.redis", () => Task.FromResult<IConnectionMultiplexer>(snapshotMultiplexer));
+
+var setup = ActorSystemSetup.Create(
+    BootstrapSetup.Create().WithConfig(redisHocon),
+    multi);
+
+var system = ActorSystem.Create("my-system", setup);
+```
+
+The journal and snapshot store actors will pick up the setup the moment they need to connect.
+
 ### Health Checks
 
 The Hosting package includes built-in connectivity health check support for verifying Redis availability and accessibility. These liveness checks proactively verify that your Redis instance is accessible and responsive by performing PING commands against the configured Redis instance.

--- a/src/Akka.Persistence.Redis.Hosting/AkkaPersistenceRedisHostingExtensions.cs
+++ b/src/Akka.Persistence.Redis.Hosting/AkkaPersistenceRedisHostingExtensions.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Linq;
 using System.Text;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
+using Akka.Persistence.Redis;
 
 #nullable enable
 namespace Akka.Persistence.Redis.Hosting;
@@ -212,6 +214,32 @@ public static class AkkaPersistenceRedisHostingExtensions
         Action<AkkaPersistenceJournalBuilder>? journalBuilder = null,
         Action<AkkaPersistenceSnapshotBuilder>? snapshotBuilder = null)
     {
+        // Carry per-plugin factories through ActorSystemSetup, mirroring how Akka.Persistence.Sql
+        // ships DataOptions via MultiDataOptionsSetup. Each plugin's options can supply its own
+        // factory (the common case is one shared factory across journal+snapshot, but multiple
+        // plugin instances against different Redis backends — e.g. Cluster.Sharding regions —
+        // are supported by setting different delegates per options object). The journal and
+        // snapshot store actors read this back via
+        // Context.System.Settings.Setup.Get<MultiRedisConnectionMultiplexerSetup>(), keyed by
+        // their own plugin path.
+        var journalFactory = journalOptions?.ConnectionMultiplexerFactory;
+        var snapshotFactory = snapshotOptions?.ConnectionMultiplexerFactory;
+        if (journalFactory is not null || snapshotFactory is not null)
+        {
+            var multi = builder.Setups.OfType<MultiRedisConnectionMultiplexerSetup>().FirstOrDefault();
+            if (multi is null)
+            {
+                multi = new MultiRedisConnectionMultiplexerSetup();
+                builder.Setups.Add(multi);
+            }
+
+            if (journalFactory is not null && journalOptions is not null)
+                multi.AddFactory(journalOptions.PluginId, journalFactory);
+
+            if (snapshotFactory is not null && snapshotOptions is not null)
+                multi.AddFactory(snapshotOptions.PluginId, snapshotFactory);
+        }
+
         return (journalOptions, snapshotOptions) switch
         {
             (null, null) =>
@@ -225,7 +253,8 @@ public static class AkkaPersistenceRedisHostingExtensions
 
             (null, _) =>
                 builder
-                    .WithSnapshot(snapshotOptions, snapshotBuilder),
+                    .WithSnapshot(snapshotOptions, snapshotBuilder)
+                    .AddHocon(RedisPersistence.DefaultConfig(), HoconAddMode.Append),
 
             (_, _) =>
                 builder

--- a/src/Akka.Persistence.Redis.Hosting/RedisConnectivityCheckExtensions.cs
+++ b/src/Akka.Persistence.Redis.Hosting/RedisConnectivityCheckExtensions.cs
@@ -33,12 +33,11 @@ public static class RedisConnectivityCheckExtensions
             ?? throw new InvalidOperationException(
                 $"Options must be {nameof(RedisJournalOptions)}");
 
-        if (string.IsNullOrWhiteSpace(journalOptions.ConfigurationString))
-            throw new ArgumentException("ConfigurationString must be set on RedisJournalOptions");
+        var check = BuildJournalCheck(journalOptions);
 
         var registration = new AkkaHealthCheckRegistration(
             name ?? $"Akka.Persistence.Redis.Journal.{journalOptions.Identifier}.Connectivity",
-            new RedisJournalConnectivityCheck(journalOptions.ConfigurationString!, journalOptions.Identifier),
+            check,
             unHealthyStatus,
             tags ?? new[] { "akka", "persistence", "redis", "journal", "connectivity" });
 
@@ -66,12 +65,11 @@ public static class RedisConnectivityCheckExtensions
         if (journalOptions is null)
             throw new ArgumentNullException(nameof(journalOptions));
 
-        if (string.IsNullOrWhiteSpace(journalOptions.ConfigurationString))
-            throw new ArgumentException("ConfigurationString must be set on RedisJournalOptions", nameof(journalOptions));
+        var check = BuildJournalCheck(journalOptions);
 
         var registration = new AkkaHealthCheckRegistration(
             name ?? $"Akka.Persistence.Redis.Journal.{journalOptions.Identifier}.Connectivity",
-            new RedisJournalConnectivityCheck(journalOptions.ConfigurationString, journalOptions.Identifier),
+            check,
             unHealthyStatus,
             tags ?? new[] { "akka", "persistence", "redis", "journal", "connectivity" });
 
@@ -99,12 +97,11 @@ public static class RedisConnectivityCheckExtensions
             ?? throw new InvalidOperationException(
                 $"Options must be {nameof(RedisSnapshotOptions)}");
 
-        if (string.IsNullOrWhiteSpace(snapshotOptions.ConfigurationString))
-            throw new ArgumentException("ConfigurationString must be set on RedisSnapshotOptions");
+        var check = BuildSnapshotStoreCheck(snapshotOptions);
 
         var registration = new AkkaHealthCheckRegistration(
             name ?? $"Akka.Persistence.Redis.SnapshotStore.{snapshotOptions.Identifier}.Connectivity",
-            new RedisSnapshotStoreConnectivityCheck(snapshotOptions.ConfigurationString!, snapshotOptions.Identifier),
+            check,
             unHealthyStatus,
             tags ?? new[] { "akka", "persistence", "redis", "snapshot-store", "connectivity" });
 
@@ -132,15 +129,43 @@ public static class RedisConnectivityCheckExtensions
         if (snapshotOptions is null)
             throw new ArgumentNullException(nameof(snapshotOptions));
 
-        if (string.IsNullOrWhiteSpace(snapshotOptions.ConfigurationString))
-            throw new ArgumentException("ConfigurationString must be set on RedisSnapshotOptions", nameof(snapshotOptions));
+        var check = BuildSnapshotStoreCheck(snapshotOptions);
 
         var registration = new AkkaHealthCheckRegistration(
             name ?? $"Akka.Persistence.Redis.SnapshotStore.{snapshotOptions.Identifier}.Connectivity",
-            new RedisSnapshotStoreConnectivityCheck(snapshotOptions.ConfigurationString, snapshotOptions.Identifier),
+            check,
             unHealthyStatus,
             tags ?? new[] { "akka", "persistence", "redis", "snapshot-store", "connectivity" });
 
         return builder.WithCustomHealthCheck(registration);
+    }
+
+    // When ConnectionMultiplexerFactory is set on the options, route the health check
+    // through the same factory the journal/snapshot store uses so the probe reuses the
+    // caller-owned multiplexer instead of opening a fresh connection per check. Falls
+    // back to the connection-string ctor (which opens-and-disposes per probe) when no
+    // factory is configured.
+    private static RedisJournalConnectivityCheck BuildJournalCheck(RedisJournalOptions options)
+    {
+        if (options.ConnectionMultiplexerFactory is not null)
+            return new RedisJournalConnectivityCheck(options.ConnectionMultiplexerFactory, options.Identifier);
+
+        if (string.IsNullOrWhiteSpace(options.ConfigurationString))
+            throw new ArgumentException(
+                $"Either {nameof(RedisJournalOptions.ConfigurationString)} or {nameof(RedisJournalOptions.ConnectionMultiplexerFactory)} must be set on {nameof(RedisJournalOptions)}.");
+
+        return new RedisJournalConnectivityCheck(options.ConfigurationString!, options.Identifier);
+    }
+
+    private static RedisSnapshotStoreConnectivityCheck BuildSnapshotStoreCheck(RedisSnapshotOptions options)
+    {
+        if (options.ConnectionMultiplexerFactory is not null)
+            return new RedisSnapshotStoreConnectivityCheck(options.ConnectionMultiplexerFactory, options.Identifier);
+
+        if (string.IsNullOrWhiteSpace(options.ConfigurationString))
+            throw new ArgumentException(
+                $"Either {nameof(RedisSnapshotOptions.ConfigurationString)} or {nameof(RedisSnapshotOptions.ConnectionMultiplexerFactory)} must be set on {nameof(RedisSnapshotOptions)}.");
+
+        return new RedisSnapshotStoreConnectivityCheck(options.ConfigurationString!, options.Identifier);
     }
 }

--- a/src/Akka.Persistence.Redis.Hosting/RedisJournalConnectivityCheck.cs
+++ b/src/Akka.Persistence.Redis.Hosting/RedisJournalConnectivityCheck.cs
@@ -19,24 +19,61 @@ namespace Akka.Persistence.Redis.Hosting;
 /// Health check that verifies connectivity to the Redis instance used by the journal.
 /// This is a liveness check that proactively verifies backend connectivity.
 /// </summary>
+/// <remarks>
+/// When constructed with a connection string, every check opens a fresh
+/// <see cref="ConnectionMultiplexer"/> and disposes it after the ping completes.
+/// That is fine for occasional liveness probes but adds connect-time latency on
+/// every check. When constructed with a factory delegate, the check reuses whatever
+/// <see cref="IConnectionMultiplexer"/> the caller already owns and does <i>not</i>
+/// dispose it — typically the same multiplexer the journal is using, so the probe is
+/// effectively zero-cost.
+/// </remarks>
 public sealed class RedisJournalConnectivityCheck : IAkkaHealthCheck
 {
-    private readonly string _connectionString;
+    private readonly Func<Task<IConnectionMultiplexer>> _connectionFactory;
+    private readonly bool _ownsConnection;
     private readonly string _journalId;
 
+    /// <summary>
+    /// Creates a connectivity check that opens a fresh <see cref="ConnectionMultiplexer"/>
+    /// from <paramref name="connectionString"/> on every probe and disposes it after the
+    /// ping completes.
+    /// </summary>
     public RedisJournalConnectivityCheck(string connectionString, string journalId)
+        : this(BuildFactoryFromConnectionString(connectionString), ownsConnection: true, journalId)
     {
-        _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+    }
+
+    /// <summary>
+    /// Creates a connectivity check that reuses a caller-supplied
+    /// <see cref="IConnectionMultiplexer"/> via <paramref name="connectionFactory"/> and
+    /// does not dispose it. The factory should typically be the same delegate registered
+    /// with <see cref="RedisConnectionProvider"/>; opening a separate multiplexer per check
+    /// defeats the point of the extension point.
+    /// </summary>
+    public RedisJournalConnectivityCheck(Func<Task<IConnectionMultiplexer>> connectionFactory, string journalId)
+        : this(connectionFactory, ownsConnection: false, journalId)
+    {
+    }
+
+    private RedisJournalConnectivityCheck(
+        Func<Task<IConnectionMultiplexer>> connectionFactory,
+        bool ownsConnection,
+        string journalId)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+        _ownsConnection = ownsConnection;
         _journalId = journalId ?? throw new ArgumentNullException(nameof(journalId));
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(AkkaHealthCheckContext context, CancellationToken cancellationToken = default)
     {
+        IConnectionMultiplexer? connection = null;
         try
         {
-            using var connection = await ConnectionMultiplexer.ConnectAsync(_connectionString);
+            connection = await _connectionFactory().ConfigureAwait(false);
             var server = connection.GetServer(connection.GetEndPoints().First());
-            await server.PingAsync();
+            await server.PingAsync().ConfigureAwait(false);
             return HealthCheckResult.Healthy($"Redis journal '{_journalId}' connection successful");
         }
         catch (OperationCanceledException)
@@ -47,5 +84,18 @@ public sealed class RedisJournalConnectivityCheck : IAkkaHealthCheck
         {
             return HealthCheckResult.Unhealthy($"Redis journal '{_journalId}' connection failed", ex);
         }
+        finally
+        {
+            if (_ownsConnection && connection is not null)
+                connection.Dispose();
+        }
+    }
+
+    private static Func<Task<IConnectionMultiplexer>> BuildFactoryFromConnectionString(string connectionString)
+    {
+        if (connectionString is null)
+            throw new ArgumentNullException(nameof(connectionString));
+
+        return async () => await ConnectionMultiplexer.ConnectAsync(connectionString).ConfigureAwait(false);
     }
 }

--- a/src/Akka.Persistence.Redis.Hosting/RedisJournalOptions.cs
+++ b/src/Akka.Persistence.Redis.Hosting/RedisJournalOptions.cs
@@ -1,7 +1,10 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
+using StackExchange.Redis;
 
 #nullable enable
 namespace Akka.Persistence.Redis.Hosting;
@@ -38,6 +41,24 @@ public class RedisJournalOptions : JournalOptions
     /// Determines redis database precedence when a user adds defaultDatabase to the connection-strings. For Redis Cluster, the defaultDatabase is 0
     /// </summary>
     public bool? UseDatabaseFromConnectionString { get; set; }
+
+    /// <summary>
+    /// Optional factory that returns a pre-configured <see cref="IConnectionMultiplexer"/>.
+    /// When set, the journal will use this multiplexer instead of opening one from
+    /// <see cref="ConfigurationString"/>. Required for scenarios that need a programmatically
+    /// authored <see cref="ConfigurationOptions"/> (Azure Managed Redis with Entra ID,
+    /// Redis Sentinel, custom <see cref="ConfigurationOptions.ReconnectRetryPolicy"/>,
+    /// shorter <see cref="ConfigurationOptions.ConfigCheckSeconds"/> for clustered Redis, etc.).
+    /// </summary>
+    /// <remarks>
+    /// The multiplexer is treated as caller-owned: the plugin will <i>not</i> dispose it on
+    /// actor shutdown. The factory should cache and return the same instance on every call.
+    /// If <see cref="WithRedisSnapshot"/>-style configuration also sets a factory on
+    /// <see cref="RedisSnapshotOptions.ConnectionMultiplexerFactory"/>, the two delegates
+    /// must be the same reference; otherwise <see cref="AkkaPersistenceRedisHostingExtensions"/>
+    /// will throw because the underlying registry is process-global.
+    /// </remarks>
+    public Func<Task<IConnectionMultiplexer>>? ConnectionMultiplexerFactory { get; set; }
 
     public override string Identifier { get; set; }
     protected override Config InternalDefaultConfig { get; } = Default;

--- a/src/Akka.Persistence.Redis.Hosting/RedisSnapshotOptions.cs
+++ b/src/Akka.Persistence.Redis.Hosting/RedisSnapshotOptions.cs
@@ -1,7 +1,10 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
+using StackExchange.Redis;
 
 #nullable enable
 namespace Akka.Persistence.Redis.Hosting;
@@ -39,6 +42,23 @@ public class RedisSnapshotOptions : SnapshotOptions
     /// Determines redis database precedence when a user adds defaultDatabase to the connection-strings. For Redis Cluster, the defaultDatabase is 0
     /// </summary>
     public bool? UseDatabaseFromConnectionString { get; set; }
+
+    /// <summary>
+    /// Optional factory that returns a pre-configured <see cref="IConnectionMultiplexer"/>.
+    /// When set, the snapshot store will use this multiplexer instead of opening one from
+    /// <see cref="ConfigurationString"/>. Required for scenarios that need a programmatically
+    /// authored <see cref="ConfigurationOptions"/> (Azure Managed Redis with Entra ID,
+    /// Redis Sentinel, custom <see cref="ConfigurationOptions.ReconnectRetryPolicy"/>,
+    /// shorter <see cref="ConfigurationOptions.ConfigCheckSeconds"/> for clustered Redis, etc.).
+    /// </summary>
+    /// <remarks>
+    /// The multiplexer is treated as caller-owned: the plugin will <i>not</i> dispose it on
+    /// actor shutdown. The factory should cache and return the same instance on every call.
+    /// If <see cref="RedisJournalOptions.ConnectionMultiplexerFactory"/> is also set, the two
+    /// delegates must be the same reference; otherwise <see cref="AkkaPersistenceRedisHostingExtensions"/>
+    /// will throw because the underlying registry is process-global.
+    /// </remarks>
+    public Func<Task<IConnectionMultiplexer>>? ConnectionMultiplexerFactory { get; set; }
 
     public override string Identifier { get; set; }
     protected override Config InternalDefaultConfig { get; } = Default;

--- a/src/Akka.Persistence.Redis.Hosting/RedisSnapshotStoreConnectivityCheck.cs
+++ b/src/Akka.Persistence.Redis.Hosting/RedisSnapshotStoreConnectivityCheck.cs
@@ -19,24 +19,61 @@ namespace Akka.Persistence.Redis.Hosting;
 /// Health check that verifies connectivity to the Redis instance used by the snapshot store.
 /// This is a liveness check that proactively verifies backend connectivity.
 /// </summary>
+/// <remarks>
+/// When constructed with a connection string, every check opens a fresh
+/// <see cref="ConnectionMultiplexer"/> and disposes it after the ping completes.
+/// That is fine for occasional liveness probes but adds connect-time latency on
+/// every check. When constructed with a factory delegate, the check reuses whatever
+/// <see cref="IConnectionMultiplexer"/> the caller already owns and does <i>not</i>
+/// dispose it — typically the same multiplexer the snapshot store is using, so the probe
+/// is effectively zero-cost.
+/// </remarks>
 public sealed class RedisSnapshotStoreConnectivityCheck : IAkkaHealthCheck
 {
-    private readonly string _connectionString;
+    private readonly Func<Task<IConnectionMultiplexer>> _connectionFactory;
+    private readonly bool _ownsConnection;
     private readonly string _snapshotStoreId;
 
+    /// <summary>
+    /// Creates a connectivity check that opens a fresh <see cref="ConnectionMultiplexer"/>
+    /// from <paramref name="connectionString"/> on every probe and disposes it after the
+    /// ping completes.
+    /// </summary>
     public RedisSnapshotStoreConnectivityCheck(string connectionString, string snapshotStoreId)
+        : this(BuildFactoryFromConnectionString(connectionString), ownsConnection: true, snapshotStoreId)
     {
-        _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+    }
+
+    /// <summary>
+    /// Creates a connectivity check that reuses a caller-supplied
+    /// <see cref="IConnectionMultiplexer"/> via <paramref name="connectionFactory"/> and
+    /// does not dispose it. The factory should typically be the same delegate registered
+    /// with <see cref="RedisConnectionProvider"/>; opening a separate multiplexer per check
+    /// defeats the point of the extension point.
+    /// </summary>
+    public RedisSnapshotStoreConnectivityCheck(Func<Task<IConnectionMultiplexer>> connectionFactory, string snapshotStoreId)
+        : this(connectionFactory, ownsConnection: false, snapshotStoreId)
+    {
+    }
+
+    private RedisSnapshotStoreConnectivityCheck(
+        Func<Task<IConnectionMultiplexer>> connectionFactory,
+        bool ownsConnection,
+        string snapshotStoreId)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+        _ownsConnection = ownsConnection;
         _snapshotStoreId = snapshotStoreId ?? throw new ArgumentNullException(nameof(snapshotStoreId));
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(AkkaHealthCheckContext context, CancellationToken cancellationToken = default)
     {
+        IConnectionMultiplexer? connection = null;
         try
         {
-            using var connection = await ConnectionMultiplexer.ConnectAsync(_connectionString);
+            connection = await _connectionFactory().ConfigureAwait(false);
             var server = connection.GetServer(connection.GetEndPoints().First());
-            await server.PingAsync();
+            await server.PingAsync().ConfigureAwait(false);
             return HealthCheckResult.Healthy($"Redis snapshot store '{_snapshotStoreId}' connection successful");
         }
         catch (OperationCanceledException)
@@ -47,5 +84,18 @@ public sealed class RedisSnapshotStoreConnectivityCheck : IAkkaHealthCheck
         {
             return HealthCheckResult.Unhealthy($"Redis snapshot store '{_snapshotStoreId}' connection failed", ex);
         }
+        finally
+        {
+            if (_ownsConnection && connection is not null)
+                connection.Dispose();
+        }
+    }
+
+    private static Func<Task<IConnectionMultiplexer>> BuildFactoryFromConnectionString(string connectionString)
+    {
+        if (connectionString is null)
+            throw new ArgumentNullException(nameof(connectionString));
+
+        return async () => await ConnectionMultiplexer.ConnectAsync(connectionString).ConfigureAwait(false);
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/Hosting/ConnectionMultiplexerFactorySpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/ConnectionMultiplexerFactorySpec.cs
@@ -1,0 +1,116 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ConnectionMultiplexerFactorySpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Persistence;
+using Akka.Persistence.Redis;
+using Akka.Persistence.Redis.Hosting;
+using Akka.Persistence.Redis.Tests;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Tests.Hosting;
+
+[Collection("RedisSpec")]
+public class ConnectionMultiplexerFactorySpec : Akka.Hosting.TestKit.TestKit, IClassFixture<RedisFixture>
+{
+    private readonly RedisFixture _fixture;
+    private IConnectionMultiplexer? _suppliedMultiplexer;
+
+    public ConnectionMultiplexerFactorySpec(ITestOutputHelper output, RedisFixture fixture)
+        : base(nameof(ConnectionMultiplexerFactorySpec), output: output)
+    {
+        _fixture = fixture;
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        _suppliedMultiplexer = ConnectionMultiplexer.Connect(_fixture.ConnectionString);
+        Func<Task<IConnectionMultiplexer>> sharedFactory = () => Task.FromResult(_suppliedMultiplexer!);
+
+        builder.WithRedisPersistence(
+            journalOptionConfigurator: opts =>
+            {
+                opts.AutoInitialize = true;
+                opts.ConnectionMultiplexerFactory = sharedFactory;
+            },
+            snapshotOptionConfigurator: opts =>
+            {
+                opts.AutoInitialize = true;
+                // Same delegate reference required by the factory-consistency check.
+                opts.ConnectionMultiplexerFactory = sharedFactory;
+            });
+    }
+
+    protected override async Task AfterAllAsync()
+    {
+        // Caller-owned multiplexer: the plugin must NOT have disposed it.
+        _suppliedMultiplexer.Should().NotBeNull();
+        _suppliedMultiplexer!.IsConnected.Should().BeTrue(
+            "the plugin must not dispose multiplexers supplied via ConnectionMultiplexerFactory");
+
+        _suppliedMultiplexer.Dispose();
+        // The per-system registry entry will be GC'd with Sys; explicit Reset is just hygiene.
+
+        await base.AfterAllAsync();
+    }
+
+    [Fact]
+    public async Task Caller_supplied_multiplexer_should_round_trip_through_the_journal()
+    {
+        var actor = Sys.ActorOf(Props.Create(() => new FactoryProbeActor("factory-probe-1", TestActor)));
+
+        actor.Tell("save");
+        ExpectMsg("saved", TimeSpan.FromSeconds(10));
+
+        // Recover via a fresh actor to confirm the write actually landed in Redis through
+        // the supplied multiplexer (not just acknowledged).
+        var recovered = Sys.ActorOf(Props.Create(() => new FactoryProbeActor("factory-probe-1", TestActor)));
+        ExpectMsg("recovered:save", TimeSpan.FromSeconds(10));
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public void MultiSetup_should_carry_factories_for_both_journal_and_snapshot_plugin_ids()
+    {
+        // Sanity: the hosting extension added a MultiRedisConnectionMultiplexerSetup to
+        // ActorSystemSetup with one entry per plugin id (journal + snapshot here).
+        var setup = Sys.Settings.Setup.Get<MultiRedisConnectionMultiplexerSetup>();
+        setup.HasValue.Should().BeTrue();
+
+        setup.Value.TryGetFactory("akka.persistence.journal.redis", out _).Should().BeTrue();
+        setup.Value.TryGetFactory("akka.persistence.snapshot-store.redis", out _).Should().BeTrue();
+    }
+
+    private sealed class FactoryProbeActor : Akka.Persistence.ReceivePersistentActor
+    {
+        private readonly string _persistenceId;
+
+        public FactoryProbeActor(string persistenceId, IActorRef probe)
+        {
+            _persistenceId = persistenceId;
+
+            Recover<string>(payload => probe.Tell($"recovered:{payload}"));
+
+            Command<string>(msg =>
+            {
+                if (msg == "save")
+                {
+                    Persist(msg, _ => probe.Tell("saved"));
+                }
+            });
+        }
+
+        public override string PersistenceId => _persistenceId;
+    }
+}

--- a/src/Akka.Persistence.Redis.Tests/Hosting/FactoryRoutingSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/FactoryRoutingSpec.cs
@@ -1,0 +1,129 @@
+// -----------------------------------------------------------------------
+//  <copyright file="FactoryRoutingSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Hosting;
+using Akka.Persistence.Redis;
+using Akka.Persistence.Redis.Hosting;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Tests.Hosting;
+
+/// <summary>
+/// Verifies the hosting extension's per-plugin factory routing semantics. Journal and
+/// snapshot store can supply the same factory delegate (single shared multiplexer, the
+/// common case), different factories (per-plugin instances against different Redis
+/// backends), or a factory on only one side (HOCON connection-string for the other).
+/// All three cases must be accepted at config time.
+/// </summary>
+public class FactoryRoutingSpec
+{
+    [Fact]
+    public void WithRedisPersistence_should_accept_same_factory_reference_on_both()
+    {
+        Func<Task<IConnectionMultiplexer>> shared = () => Task.FromResult<IConnectionMultiplexer>(null!);
+
+        var journalOptions = new RedisJournalOptions
+        {
+            ConfigurationString = "localhost:6379",
+            ConnectionMultiplexerFactory = shared,
+        };
+
+        var snapshotOptions = new RedisSnapshotOptions
+        {
+            ConfigurationString = "localhost:6379",
+            ConnectionMultiplexerFactory = shared,
+        };
+
+        var builder = NewBuilder();
+
+        Action act = () => builder.WithRedisPersistence(journalOptions, snapshotOptions);
+
+        act.Should().NotThrow();
+
+        var multi = builder.Setups.OfType<MultiRedisConnectionMultiplexerSetup>().FirstOrDefault();
+        multi.Should().NotBeNull();
+        multi!.TryGetFactory(journalOptions.PluginId, out _).Should().BeTrue();
+        multi.TryGetFactory(snapshotOptions.PluginId, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void WithRedisPersistence_should_accept_different_factories_for_journal_and_snapshot()
+    {
+        // Different multiplexers per plugin id — exactly what cluster-sharding / multi-tenant
+        // setups need when journal events live on a different Redis from snapshots.
+        Func<Task<IConnectionMultiplexer>> journalFactory = () => Task.FromResult<IConnectionMultiplexer>(null!);
+        Func<Task<IConnectionMultiplexer>> snapshotFactory = () => Task.FromResult<IConnectionMultiplexer>(null!);
+
+        var journalOptions = new RedisJournalOptions
+        {
+            ConfigurationString = "localhost:6379",
+            ConnectionMultiplexerFactory = journalFactory,
+        };
+
+        var snapshotOptions = new RedisSnapshotOptions
+        {
+            ConfigurationString = "localhost:7000",
+            ConnectionMultiplexerFactory = snapshotFactory,
+        };
+
+        var builder = NewBuilder();
+
+        Action act = () => builder.WithRedisPersistence(journalOptions, snapshotOptions);
+
+        act.Should().NotThrow();
+
+        var multi = builder.Setups.OfType<MultiRedisConnectionMultiplexerSetup>().FirstOrDefault();
+        multi.Should().NotBeNull();
+
+        multi!.TryGetFactory(journalOptions.PluginId, out var journalRegistered).Should().BeTrue();
+        ReferenceEquals(journalRegistered, journalFactory).Should().BeTrue();
+
+        multi.TryGetFactory(snapshotOptions.PluginId, out var snapshotRegistered).Should().BeTrue();
+        ReferenceEquals(snapshotRegistered, snapshotFactory).Should().BeTrue();
+    }
+
+    [Fact]
+    public void WithRedisPersistence_should_accept_factory_on_only_one_side()
+    {
+        Func<Task<IConnectionMultiplexer>> factory = () => Task.FromResult<IConnectionMultiplexer>(null!);
+
+        var journalOptions = new RedisJournalOptions
+        {
+            ConfigurationString = "localhost:6379",
+            ConnectionMultiplexerFactory = factory,
+        };
+
+        var snapshotOptions = new RedisSnapshotOptions
+        {
+            ConfigurationString = "localhost:6379",
+            // ConnectionMultiplexerFactory left null — snapshot store will use the HOCON
+            // connection-string path, journal uses the supplied factory.
+        };
+
+        var builder = NewBuilder();
+
+        Action act = () => builder.WithRedisPersistence(journalOptions, snapshotOptions);
+
+        act.Should().NotThrow();
+
+        var multi = builder.Setups.OfType<MultiRedisConnectionMultiplexerSetup>().FirstOrDefault();
+        multi.Should().NotBeNull();
+        multi!.TryGetFactory(journalOptions.PluginId, out _).Should().BeTrue();
+        multi.TryGetFactory(snapshotOptions.PluginId, out _).Should().BeFalse();
+    }
+
+    private static AkkaConfigurationBuilder NewBuilder()
+    {
+        var services = new ServiceCollection();
+        return new AkkaConfigurationBuilder(services, "factory-routing-test");
+    }
+}

--- a/src/Akka.Persistence.Redis.Tests/Hosting/RedisConnectivityCheckSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/RedisConnectivityCheckSpec.cs
@@ -98,7 +98,7 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     public void Journal_Connectivity_Check_Should_Require_ConnectionString()
     {
         // Act & Assert
-        var action = () => new RedisJournalConnectivityCheck(null!, "redis");
+        var action = () => new RedisJournalConnectivityCheck((string)null!, "redis");
         action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "connectionString");
     }
 
@@ -114,7 +114,7 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     public void Snapshot_Connectivity_Check_Should_Require_ConnectionString()
     {
         // Act & Assert
-        var action = () => new RedisSnapshotStoreConnectivityCheck(null!, "redis");
+        var action = () => new RedisSnapshotStoreConnectivityCheck((string)null!, "redis");
         action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "connectionString");
     }
 

--- a/src/Akka.Persistence.Redis.Tests/Hosting/SnapshotOnlyHostingSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/SnapshotOnlyHostingSpec.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+//  <copyright file="SnapshotOnlyHostingSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Hosting;
+using Akka.Persistence.Hosting;
+using Akka.Persistence.Redis.Hosting;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Tests.Hosting;
+
+/// <summary>
+/// Regression coverage for the snapshot-only HOCON gap: configuring the plugin via
+/// <see cref="AkkaPersistenceRedisHostingExtensions.WithRedisPersistence(AkkaConfigurationBuilder, string, PersistenceMode, bool, Action{AkkaPersistenceJournalBuilder}, Action{AkkaPersistenceSnapshotBuilder}, string, bool)"/>
+/// with <see cref="PersistenceMode.SnapshotStore"/> previously skipped the
+/// <c>AddHocon(RedisPersistence.DefaultConfig(), HoconAddMode.Append)</c> call,
+/// leaving the snapshot store class without its HOCON section at runtime.
+/// </summary>
+[Collection("RedisSpec")]
+public class SnapshotOnlyHostingSpec : Akka.Hosting.TestKit.TestKit, IClassFixture<RedisFixture>
+{
+    private readonly RedisFixture _fixture;
+
+    public SnapshotOnlyHostingSpec(ITestOutputHelper output, RedisFixture fixture)
+        : base(nameof(SnapshotOnlyHostingSpec), output: output)
+    {
+        _fixture = fixture;
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithRedisPersistence(
+            configurationString: _fixture.ConnectionString,
+            mode: PersistenceMode.SnapshotStore);
+    }
+
+    [Fact]
+    public void Snapshot_only_configuration_should_load_redis_snapshot_store_HOCON()
+    {
+        var snapshotStoreConfig = Sys.Settings.Config.GetConfig("akka.persistence.snapshot-store.redis");
+
+        snapshotStoreConfig.Should().NotBeNull(
+            "the snapshot-only branch must call AddHocon(RedisPersistence.DefaultConfig(), HoconAddMode.Append)");
+
+        snapshotStoreConfig.GetString("class")
+            .Should().Contain("RedisSnapshotStore",
+                "the redis snapshot-store HOCON section must include the plugin class name");
+    }
+
+    [Fact]
+    public void Snapshot_only_configuration_should_set_snapshot_store_plugin_to_redis()
+    {
+        Sys.Settings.Config.GetString("akka.persistence.snapshot-store.plugin")
+            .Should().Be("akka.persistence.snapshot-store.redis");
+    }
+}

--- a/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
+++ b/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
@@ -45,12 +45,30 @@ namespace Akka.Persistence.Redis.Journal
             _system = Context.System;
             _connection = new Lazy<RedisConnection>(() =>
             {
-                var redisConnection = StackExchange.Redis.ConnectionMultiplexer.Connect(_settings.ConfigurationString);
+                IConnectionMultiplexer redisConnection;
+                bool ownsConnection;
+                var supplied = TryResolveCallerSuppliedMultiplexer();
+                if (supplied is not null)
+                {
+                    // Caller supplied a pre-configured multiplexer via ActorSystemSetup.
+                    // Reuse it and leave its lifetime to the caller; never dispose from PostStop.
+                    redisConnection = supplied;
+                    ownsConnection = false;
+                }
+                else
+                {
+                    redisConnection = StackExchange.Redis.ConnectionMultiplexer.Connect(_settings.ConfigurationString);
+                    ownsConnection = true;
+                }
+
                 IsClustered = redisConnection.IsClustered();
 
                 IDatabase database;
-                if (_settings.DatabaseFromConnectionString && !IsClustered)
+                if (ownsConnection && _settings.DatabaseFromConnectionString && !IsClustered)
                 {
+                    // DatabaseFromConnectionString is only meaningful when we own the connection
+                    // string ourselves; an injected multiplexer is opaque to us so we fall back
+                    // to the explicitly configured _settings.Database.
                     var conf = ConfigurationOptions.Parse(_settings.ConfigurationString);
                     if (conf.DefaultDatabase.HasValue)
                         database = redisConnection.GetDatabase(conf.DefaultDatabase.Value);
@@ -67,11 +85,29 @@ namespace Akka.Persistence.Redis.Journal
                     database = redisConnection.GetDatabase(_settings.Database);
                 }
 
-                // PR 1 always owns the multiplexer it creates. A future change introducing
-                // an externally-supplied ConnectionMultiplexerFactory will set this to false
-                // for caller-supplied connections so the plugin doesn't dispose them.
-                return new RedisConnection(redisConnection, database, ownsConnection: true);
+                return new RedisConnection(redisConnection, database, ownsConnection);
             });
+        }
+
+        // Looks up a caller-supplied multiplexer via ActorSystemSetup. Single-instance
+        // RedisConnectionMultiplexerSetup applies to every plugin and takes precedence;
+        // MultiRedisConnectionMultiplexerSetup is consulted as a fallback, keyed by this
+        // plugin's full HOCON path (which equals Self.Path.Name for system plugin actors).
+        // Returns null when neither setup applies, in which case the plugin opens its own
+        // multiplexer from the HOCON connection-string.
+        private IConnectionMultiplexer? TryResolveCallerSuppliedMultiplexer()
+        {
+            var setup = _system.Settings.Setup;
+
+            var single = setup.Get<RedisConnectionMultiplexerSetup>();
+            if (single.HasValue)
+                return single.Value.ConnectionFactory().GetAwaiter().GetResult();
+
+            var multi = setup.Get<MultiRedisConnectionMultiplexerSetup>();
+            if (multi.HasValue && multi.Value.TryGetFactory(Self.Path.Name, out var factory) && factory is not null)
+                return factory().GetAwaiter().GetResult();
+
+            return null;
         }
 
         protected override bool ReceivePluginInternal(object message)

--- a/src/Akka.Persistence.Redis/RedisConnectionMultiplexerSetup.cs
+++ b/src/Akka.Persistence.Redis/RedisConnectionMultiplexerSetup.cs
@@ -1,0 +1,139 @@
+// -----------------------------------------------------------------------
+//  <copyright file="RedisConnectionMultiplexerSetup.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using StackExchange.Redis;
+
+namespace Akka.Persistence.Redis
+{
+    /// <summary>
+    /// Per-<see cref="ActorSystem"/> setup that supplies a single pre-configured
+    /// <see cref="IConnectionMultiplexer"/> to <i>all</i> Redis journal and snapshot store
+    /// instances in the system. Use this when one Redis instance backs every Redis
+    /// persistence plugin in the application — the common case.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For applications that run multiple instances of the Redis journal or snapshot store
+    /// against <i>different</i> Redis instances (multi-tenant sharding, journal vs snapshot
+    /// on separate Redis tiers, migration cutovers, etc.), use
+    /// <see cref="MultiRedisConnectionMultiplexerSetup"/> instead — it carries one factory
+    /// per plugin id.
+    /// </para>
+    /// <para>
+    /// <b>Lookup order.</b> When both this setup and <see cref="MultiRedisConnectionMultiplexerSetup"/>
+    /// are present on the same <see cref="ActorSystem"/>, the single setup wins for every
+    /// plugin instance. The multi setup is consulted only when the single setup is absent.
+    /// </para>
+    /// <para>
+    /// <b>Lifetime contract.</b> The plugin treats the multiplexer returned by the factory
+    /// as caller-owned and will <i>not</i> dispose it during <see cref="UntypedActor.PostStop"/>.
+    /// The factory should typically cache and return the same
+    /// <see cref="IConnectionMultiplexer"/> on every invocation.
+    /// </para>
+    /// <para>
+    /// <b>Akka.Hosting users</b> normally do not construct this setup directly; setting
+    /// <see cref="P:Akka.Persistence.Redis.Hosting.RedisJournalOptions.ConnectionMultiplexerFactory"/>
+    /// (and/or its snapshot-store equivalent) on the hosting options causes the hosting
+    /// extension to assemble an appropriate Setup. Construct this class explicitly only
+    /// when bootstrapping an <see cref="ActorSystem"/> outside Akka.Hosting via
+    /// <see cref="ActorSystem.Create(string, ActorSystemSetup)"/>.
+    /// </para>
+    /// </remarks>
+    public sealed class RedisConnectionMultiplexerSetup : Setup
+    {
+        public RedisConnectionMultiplexerSetup(Func<Task<IConnectionMultiplexer>> connectionFactory)
+        {
+            ConnectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+        }
+
+        /// <summary>
+        /// Convenience factory method for constructing a setup from a synchronous factory
+        /// (e.g. when the caller already has a fully-constructed multiplexer).
+        /// </summary>
+        public static RedisConnectionMultiplexerSetup Create(Func<IConnectionMultiplexer> connectionFactory)
+        {
+            if (connectionFactory is null) throw new ArgumentNullException(nameof(connectionFactory));
+            return new RedisConnectionMultiplexerSetup(() => Task.FromResult(connectionFactory()));
+        }
+
+        public Func<Task<IConnectionMultiplexer>> ConnectionFactory { get; }
+    }
+
+    /// <summary>
+    /// Per-<see cref="ActorSystem"/> setup that supplies a different
+    /// <see cref="IConnectionMultiplexer"/> factory for each Redis journal or snapshot store
+    /// instance, keyed by plugin id (the full HOCON path, e.g.
+    /// <c>"akka.persistence.journal.redis"</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use this when an application runs multiple Redis persistence plugin instances against
+    /// different Redis backends — for example: cluster sharding regions backed by different
+    /// Redis clusters, journal events on a fast write-tuned Redis with snapshots on a
+    /// separate durable Redis, or a temporary migration cutover where new writes go to one
+    /// backend while reads still hit another.
+    /// </para>
+    /// <para>
+    /// Plugin ids are the full HOCON paths of the journal or snapshot store configuration
+    /// section — e.g. <c>"akka.persistence.journal.redis"</c> for the default journal,
+    /// <c>"akka.persistence.snapshot-store.redis"</c> for the default snapshot store, or
+    /// <c>"akka.persistence.journal.region-a"</c> for a custom-id journal. The key set is
+    /// independent: a journal at <c>"akka.persistence.journal.redis"</c> and a snapshot
+    /// store at <c>"akka.persistence.snapshot-store.redis"</c> can carry different factories.
+    /// </para>
+    /// <para>
+    /// <b>Lookup order.</b> When both <see cref="RedisConnectionMultiplexerSetup"/> and
+    /// this multi setup are present on the same <see cref="ActorSystem"/>, the single
+    /// setup takes precedence and applies to every plugin instance. This multi setup is
+    /// consulted only when the single setup is absent.
+    /// </para>
+    /// <para>
+    /// <b>Lifetime contract.</b> Same as <see cref="RedisConnectionMultiplexerSetup"/>:
+    /// caller-owned multiplexers, the plugin will not dispose them on
+    /// <see cref="UntypedActor.PostStop"/>.
+    /// </para>
+    /// </remarks>
+    public sealed class MultiRedisConnectionMultiplexerSetup : Setup
+    {
+        private readonly Dictionary<string, Func<Task<IConnectionMultiplexer>>> _factories = new();
+
+        /// <summary>
+        /// Registers <paramref name="connectionFactory"/> for the plugin at
+        /// <paramref name="pluginId"/>. Existing registrations for the same plugin id are
+        /// replaced.
+        /// </summary>
+        /// <param name="pluginId">
+        /// The full HOCON path of the journal or snapshot store plugin (e.g.
+        /// <c>"akka.persistence.journal.redis"</c>).
+        /// </param>
+        /// <param name="connectionFactory">A factory delegate returning a configured multiplexer.</param>
+        public MultiRedisConnectionMultiplexerSetup AddFactory(
+            string pluginId,
+            Func<Task<IConnectionMultiplexer>> connectionFactory)
+        {
+            if (pluginId is null) throw new ArgumentNullException(nameof(pluginId));
+            if (connectionFactory is null) throw new ArgumentNullException(nameof(connectionFactory));
+            _factories[pluginId] = connectionFactory;
+            return this;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> and the registered factory if one exists for
+        /// <paramref name="pluginId"/>; otherwise returns <see langword="false"/> with a
+        /// <see langword="null"/> out parameter.
+        /// </summary>
+        public bool TryGetFactory(string pluginId, out Func<Task<IConnectionMultiplexer>>? connectionFactory)
+        {
+            if (pluginId is null) throw new ArgumentNullException(nameof(pluginId));
+            return _factories.TryGetValue(pluginId, out connectionFactory);
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs
+++ b/src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs
@@ -38,12 +38,30 @@ namespace Akka.Persistence.Redis.Snapshot
             _system = Context.System;
             _connection = new Lazy<RedisConnection>(() =>
             {
-                var redisConnection = StackExchange.Redis.ConnectionMultiplexer.Connect(_settings.ConfigurationString);
+                IConnectionMultiplexer redisConnection;
+                bool ownsConnection;
+                var supplied = TryResolveCallerSuppliedMultiplexer();
+                if (supplied is not null)
+                {
+                    // Caller supplied a pre-configured multiplexer via ActorSystemSetup.
+                    // Reuse it and leave its lifetime to the caller; never dispose from PostStop.
+                    redisConnection = supplied;
+                    ownsConnection = false;
+                }
+                else
+                {
+                    redisConnection = StackExchange.Redis.ConnectionMultiplexer.Connect(_settings.ConfigurationString);
+                    ownsConnection = true;
+                }
+
                 IsClustered = redisConnection.IsClustered();
 
                 IDatabase database;
-                if (_settings.DatabaseFromConnectionString && !IsClustered)
+                if (ownsConnection && _settings.DatabaseFromConnectionString && !IsClustered)
                 {
+                    // DatabaseFromConnectionString is only meaningful when we own the connection
+                    // string ourselves; an injected multiplexer is opaque to us so we fall back
+                    // to the explicitly configured _settings.Database.
                     var conf = ConfigurationOptions.Parse(_settings.ConfigurationString);
                     if (conf.DefaultDatabase.HasValue)
                         database = redisConnection.GetDatabase(conf.DefaultDatabase.Value);
@@ -60,11 +78,29 @@ namespace Akka.Persistence.Redis.Snapshot
                     database = redisConnection.GetDatabase(_settings.Database);
                 }
 
-                // PR 1 always owns the multiplexer it creates. A future change introducing
-                // an externally-supplied ConnectionMultiplexerFactory will set this to false
-                // for caller-supplied connections so the plugin doesn't dispose them.
-                return new RedisConnection(redisConnection, database, ownsConnection: true);
+                return new RedisConnection(redisConnection, database, ownsConnection);
             });
+        }
+
+        // Looks up a caller-supplied multiplexer via ActorSystemSetup. Single-instance
+        // RedisConnectionMultiplexerSetup applies to every plugin and takes precedence;
+        // MultiRedisConnectionMultiplexerSetup is consulted as a fallback, keyed by this
+        // plugin's full HOCON path (which equals Self.Path.Name for system plugin actors).
+        // Returns null when neither setup applies, in which case the plugin opens its own
+        // multiplexer from the HOCON connection-string.
+        private IConnectionMultiplexer? TryResolveCallerSuppliedMultiplexer()
+        {
+            var setup = _system.Settings.Setup;
+
+            var single = setup.Get<RedisConnectionMultiplexerSetup>();
+            if (single.HasValue)
+                return single.Value.ConnectionFactory().GetAwaiter().GetResult();
+
+            var multi = setup.Get<MultiRedisConnectionMultiplexerSetup>();
+            if (multi.HasValue && multi.Value.TryGetFactory(Self.Path.Name, out var factory) && factory is not null)
+                return factory().GetAwaiter().GetResult();
+
+            return null;
         }
 
         protected override void PostStop()


### PR DESCRIPTION
## Summary

Allows host applications to supply pre-configured \`IConnectionMultiplexer\` instances to the Redis journal and snapshot store instead of letting the plugin open them from a HOCON connection string. Required for scenarios that need a programmatically authored \`ConfigurationOptions\` — Azure Managed Redis with Entra ID / Managed Identity, Redis Sentinel, custom \`ReconnectRetryPolicy\`, shorter \`ConfigCheckSeconds\` for clustered Redis, etc.

Factories are carried through Akka.NET's typed per-\`ActorSystem\` \`ActorSystemSetup\` container, mirroring how \`Akka.Persistence.Sql\` carries its \`linq2db\` \`DataOptions\` and \`Akka.Persistence.Azure\` carries its Azure client configuration. Per-\`ActorSystem\` isolation comes for free; no process-global state.

### Public API additions

* \`RedisConnectionMultiplexerSetup : Akka.Actor.Setup.Setup\` — single factory, applies to every Redis plugin instance in the \`ActorSystem\`. The common case: one shared multiplexer for everything.
* \`MultiRedisConnectionMultiplexerSetup : Akka.Actor.Setup.Setup\` — \`Dictionary<pluginId, Func<...>>\` for when multiple Redis plugin instances need different backends. Cluster sharding regions on different Redis clusters, journal events on a write-tuned Redis with snapshots on a separate durable store, migration cutovers, etc.
* \`RedisJournalOptions.ConnectionMultiplexerFactory\` and \`RedisSnapshotOptions.ConnectionMultiplexerFactory\` (both \`Func<Task<IConnectionMultiplexer>>?\`, additive nullable). When set, \`WithRedisPersistence\` builds a \`MultiRedisConnectionMultiplexerSetup\` keyed by plugin id and adds it to \`AkkaConfigurationBuilder.Setups\`. Same factory on both = sharing. Different factories = per-plugin routing. No "must match" constraint.
* \`RedisJournalConnectivityCheck\` / \`RedisSnapshotStoreConnectivityCheck\` gain a constructor accepting a \`Func<Task<IConnectionMultiplexer>>\`; \`WithConnectivityCheck\` auto-routes to it when the options expose a factory, so liveness probes reuse the caller-owned multiplexer instead of opening a fresh one per check.

### Behavior fixes folded in

* **Snapshot-only hosting branch** now appends \`RedisPersistence.DefaultConfig()\` HOCON, matching the journal-only and journal+snapshot branches. Configuring the plugin via \`PersistenceMode.SnapshotStore\` previously left the snapshot store class without its HOCON section at runtime.

### Wiring

* \`RedisJournal\` and \`RedisSnapshotStore\` lazy-connection lambda reads the Single setup first, then falls back to the Multi setup keyed by \`Self.Path.Name\` (the journal/snapshot store actor's full plugin path). When neither is present, the plugin opens its own multiplexer from the HOCON connection-string, with \`ownsConnection: true\` so the existing \`PostStop\` lifecycle disposes it on shutdown. With a Setup present, \`ownsConnection: false\` and the multiplexer is left alone.

## No regression for existing users

Connection-string-only configurations work exactly as before. Setup classes are opt-in; the journal and snapshot store fall through to the HOCON path whenever no Setup is registered. Zero changes to \`reference.conf\`.

## Test coverage

* \`ConnectionMultiplexerFactorySpec\` — drives a write+read round-trip through the journal using a caller-supplied multiplexer; asserts the multiplexer is still connected after the \`ActorSystem\` terminates (proving the plugin did not dispose it). Also checks that the hosting extension populated \`MultiRedisConnectionMultiplexerSetup\` for both plugin ids.
* \`FactoryRoutingSpec\` — covers all three configurations: same factory on journal+snapshot, different factories per plugin id, and factory on only one side.
* \`SnapshotOnlyHostingSpec\` — regression coverage for the snapshot-only HOCON gap.

## Test plan

- [x] \`dotnet build -c Release\` clean (0 errors).
- [x] \`dotnet test src/Akka.Persistence.Redis.Tests/...\` — 119 passed, 0 failed, 3-for-3 stable consecutive runs locally.
- [x] \`dotnet test src/Akka.Persistence.Redis.Cluster.Tests/...\` — 89 passed, 0 failed.
- [x] README documents both single-multiplexer and per-plugin-multiplexer usage, plus the non-Akka.Hosting bootstrap path.