### PR TITLE
Trigger topology refresh on Redis Cluster replica refusal + cluster docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,65 @@ These are the minimum Redis commands that are needed by Akka.Persistence.Redis t
 | PUBLISH          | Pub/Sub Publish                  |
 
 
+## Running against Redis Cluster
+
+Redis Cluster failovers shift slot ownership between nodes. During the brief window between a node being demoted to replica and the SE.Redis client refreshing its slot-map cache, writes can be routed to a node that now refuses them (`Command cannot be issued to a replica`). Production deployments need three layers of mitigation, two of which are user-configured and the third of which the plugin does for you automatically.
+
+### 1. Tune the StackExchange.Redis connection string
+
+```
+{addresses},abortConnect=false,connectRetry=5,configCheckSeconds=10,syncTimeout=5000,asyncTimeout=5000
+```
+
+| Setting | Why |
+|---------|-----|
+| `abortConnect=false` | Without it, initial connection failures can leave the multiplexer permanently unhealthy. |
+| `connectRetry=5` | Number of times SE.Redis retries the initial connection attempt. Helps during transient failover. |
+| `configCheckSeconds=10` | How often SE.Redis re-queries cluster topology (`CLUSTER NODES`/`CLUSTER SLOTS`). Default is 60s — cutting to 10s shrinks the stale-topology window after a failover. |
+| `syncTimeout` / `asyncTimeout` (`5000` ms) | Per-operation timeouts at the SE.Redis layer. Should be **lower than** the Akka circuit-breaker `call-timeout` so the breaker trips on real hangs rather than waiting on SE.Redis's own timeout. |
+
+> Do **not** add `allowAdmin=true` unless you genuinely need admin commands (`FLUSHDB`, `CONFIG`, etc.). It enables dangerous operations and is not needed for persistence.
+
+### 2. Tune the Akka.Persistence circuit breaker and recovery concurrency
+
+```hocon
+akka.persistence {
+    max-concurrent-recoveries = 64    # or 128 for large sharded deployments — NOT higher
+    journal.redis {
+        circuit-breaker {
+            call-timeout  = 10s       # do NOT set to 120s
+            reset-timeout = 30s
+            max-failures  = 10
+        }
+    }
+    snapshot-store.redis {
+        circuit-breaker {
+            call-timeout  = 10s
+            reset-timeout = 30s
+            max-failures  = 10
+        }
+    }
+}
+```
+
+- **`max-concurrent-recoveries = 64`–`128`** — higher values turn a cluster blip into a recovery storm.
+- **`call-timeout = 10s`** — values like 120s are an **amplifier**, not a safety margin. They turn a 30-second cluster failover into a 30-minute outage by holding hundreds of in-flight recoveries open for two minutes each.
+- **App-level `Ask` timeouts must be _larger_ than `call-timeout`**, never smaller. Otherwise the `Ask` fails before the journal has any chance to fail fast its own way, and upstream consumers (RabbitMQ requeues, HTTP retries, etc.) hammer the system while persistence is still on its first attempt. Rule of thumb: `Ask timeout ≥ call-timeout × max-failures × 1.5`.
+
+### 3. What the plugin does for you automatically
+
+Two failure modes need different handling:
+
+- **`MOVED` redirects** — handled by StackExchange.Redis itself (since 2.6.86). It proactively refreshes its slot map on a 5-second debounce when it sees a `MOVED` response. No plugin involvement.
+- **`Command cannot be issued to a replica`** — runtime refusal from a node that thinks it's a replica. SE.Redis does NOT auto-handle this. The plugin catches it inside the journal and snapshot-store write paths, fires `IConnectionMultiplexer.ConfigureAsync()` in the background to force a topology refresh, and rethrows so the journal's circuit breaker handles retry timing. By the time `reset-timeout` (e.g. 30s) elapses, the refresh has completed and the next attempt sees fresh topology.
+
+No manual restart or topology poke is required.
+
+### 4. Full `ConfigurationOptions` control via `WithRedisPersistence`
+
+The connection string above expresses most of what you need, but some tunings (e.g. an `ExponentialRetry` `ReconnectRetryPolicy`, custom `SocketManager`, explicit `EndPoints`) can only be set programmatically. For those, supply a pre-configured `IConnectionMultiplexer` — see [_Supplying a Pre-Configured IConnectionMultiplexer (Non-Azure)_](#supplying-a-pre-configured-iconnectionmultiplexer-non-azure) below. The plugin's auto-topology-refresh works identically whether you let the plugin own the connection or supply your own.
+
+
 ## Akka.Hosting Integration
 
 [Akka.Persistence.Redis.Hosting](https://github.com/akkadotnet/Akka.Persistence.Redis/tree/dev/src/Akka.Persistence.Redis.Hosting) provides a set of extension methods for integrating Akka.Persistence.Redis with [Akka.Hosting](https://github.com/akkadotnet/Akka.Hosting), making it easy to configure Redis persistence and health checks using Microsoft's dependency injection and hosting model.

--- a/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
@@ -1,0 +1,167 @@
+// -----------------------------------------------------------------------
+// <copyright file="RedisTopologyRefresherSpecs.cs" company="Petabridge, LLC">
+//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Akka.Persistence.Redis.Tests
+{
+    public class RedisTopologyRefresherSpecs : Akka.TestKit.Xunit.TestKit
+    {
+        [Fact]
+        public void IsReplicaRefusal_returns_true_for_canonical_replica_message()
+        {
+            var ex = new RedisCommandException(
+                "Command cannot be issued to a replica: SET {_EventId-1}.Catalog.MarketSnapshot");
+
+            RedisTopologyRefresher.IsReplicaRefusal(ex).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsReplicaRefusal_returns_false_for_MOVED_redirect()
+        {
+            // MOVED is auto-handled by SE.Redis 2.6.86+; the refresher must NOT
+            // react to it (would cause double-refresh storms).
+            var ex = new RedisCommandException("MOVED 1234 192.168.0.5:6379");
+
+            RedisTopologyRefresher.IsReplicaRefusal(ex).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsReplicaRefusal_returns_false_for_unrelated_command_exception()
+        {
+            var ex = new RedisCommandException("WRONGTYPE Operation against a key holding the wrong kind of value");
+
+            RedisTopologyRefresher.IsReplicaRefusal(ex).Should().BeFalse();
+        }
+
+        [Fact]
+        public void TriggerBackgroundRefresh_invokes_refresh_callable_once()
+        {
+            var invocations = 0;
+            var gate = new TaskCompletionSource<int>();
+            var refresher = new RedisTopologyRefresher(
+                () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    return gate.Task;
+                },
+                Log);
+
+            refresher.TriggerBackgroundRefresh(
+                "pid-1",
+                "WriteBatch",
+                new RedisCommandException("Command cannot be issued to a replica: SET foo"));
+
+            invocations.Should().Be(1);
+
+            gate.SetResult(0);
+        }
+
+        [Fact]
+        public void TriggerBackgroundRefresh_deduplicates_concurrent_calls()
+        {
+            // Two writes hitting the same demoted node in rapid succession should
+            // result in exactly one refresh dispatch, not N.
+            var invocations = 0;
+            var gate = new TaskCompletionSource<int>();
+            var refresher = new RedisTopologyRefresher(
+                () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    return gate.Task;
+                },
+                Log);
+
+            var ex = new RedisCommandException("Command cannot be issued to a replica");
+
+            refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
+            refresher.TriggerBackgroundRefresh("pid-2", "WriteBatch", ex);
+            refresher.TriggerBackgroundRefresh("pid-3", "WriteBatch", ex);
+
+            invocations.Should().Be(1);
+
+            gate.SetResult(0);
+        }
+
+        [Fact]
+        public async Task TriggerBackgroundRefresh_resets_flag_after_refresh_completes()
+        {
+            // After the refresh task finishes, a fresh trigger must dispatch a new
+            // refresh — otherwise a one-time topology blip would permanently disable
+            // subsequent refreshes.
+            var invocations = 0;
+            TaskCompletionSource<int> gate = new();
+            var refresher = new RedisTopologyRefresher(
+                () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    return gate.Task;
+                },
+                Log);
+
+            var ex = new RedisCommandException("Command cannot be issued to a replica");
+
+            refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
+            gate.SetResult(0);
+
+            await AwaitConditionAsync(() => Task.FromResult(invocations == 1), TimeSpan.FromSeconds(2));
+
+            gate = new TaskCompletionSource<int>();
+            refresher.TriggerBackgroundRefresh("pid-2", "WriteBatch", ex);
+
+            await AwaitConditionAsync(() => Task.FromResult(invocations == 2), TimeSpan.FromSeconds(2));
+
+            gate.SetResult(0);
+        }
+
+        [Fact]
+        public async Task TriggerBackgroundRefresh_logs_warning_when_refresh_faults()
+        {
+            // When the background refresh task itself faults, we must log the failure
+            // (the operator's only signal that auto-refresh isn't working) and reset
+            // the flag so future triggers can try again.
+            var refresher = new RedisTopologyRefresher(
+                () => Task.FromException(new InvalidOperationException("simulated async failure")),
+                Log);
+
+            var ex = new RedisCommandException("Command cannot be issued to a replica");
+
+            await EventFilter.Warning(contains: "Background Redis topology refresh failed").ExpectAsync(1, async () =>
+            {
+                refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
+                await Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public void TriggerBackgroundRefresh_swallows_synchronous_refresh_exception()
+        {
+            // If the refresh callable throws synchronously (before returning a Task),
+            // the refresher must not propagate (it's fire-and-forget by contract) and
+            // must reset the in-flight flag so future writes can trigger a fresh refresh.
+            var invocations = 0;
+            var refresher = new RedisTopologyRefresher(
+                () =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    throw new InvalidOperationException("simulated synchronous failure");
+                },
+                Log);
+
+            var ex = new RedisCommandException("Command cannot be issued to a replica");
+
+            Action act = () => refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
+            act.Should().NotThrow();
+
+            AwaitAssert(() => invocations.Should().BeGreaterOrEqualTo(1), TimeSpan.FromSeconds(2));
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
@@ -101,7 +101,10 @@ namespace Akka.Persistence.Redis.Tests
         {
             // After the refresh task finishes, a fresh trigger must dispatch a new
             // refresh — otherwise a one-time topology blip would permanently disable
-            // subsequent refreshes.
+            // subsequent refreshes. The flag is reset in RunRefreshAsync's finally,
+            // which runs asynchronously after the inner Task completes, so the test
+            // polls the second trigger rather than relying on it firing on the first
+            // attempt.
             var invocations = 0;
             TaskCompletionSource<int> gate = new();
             var refresher = new RedisTopologyRefresher(
@@ -115,14 +118,15 @@ namespace Akka.Persistence.Redis.Tests
             var ex = new RedisCommandException("Command cannot be issued to a replica");
 
             refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
+            invocations.Should().Be(1);
             gate.SetResult(0);
 
-            await AwaitConditionAsync(() => Task.FromResult(invocations == 1), TimeSpan.FromSeconds(2));
-
             gate = new TaskCompletionSource<int>();
-            refresher.TriggerBackgroundRefresh("pid-2", "WriteBatch", ex);
-
-            await AwaitConditionAsync(() => Task.FromResult(invocations == 2), TimeSpan.FromSeconds(2));
+            await AwaitAssertAsync(() =>
+            {
+                refresher.TriggerBackgroundRefresh("pid-2", "WriteBatch", ex);
+                invocations.Should().Be(2);
+            }, TimeSpan.FromSeconds(2));
 
             gate.SetResult(0);
         }
@@ -147,7 +151,7 @@ namespace Akka.Persistence.Redis.Tests
         }
 
         [Fact]
-        public void TriggerBackgroundRefresh_swallows_synchronous_refresh_exception()
+        public async Task TriggerBackgroundRefresh_swallows_synchronous_refresh_exception()
         {
             // If the refresh callable throws synchronously (before returning a Task),
             // the refresher must not propagate (it's fire-and-forget by contract) and
@@ -166,7 +170,7 @@ namespace Akka.Persistence.Redis.Tests
             Action act = () => refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
             act.Should().NotThrow();
 
-            AwaitAssert(() => invocations.Should().BeGreaterOrEqualTo(1), TimeSpan.FromSeconds(2));
+            await AwaitAssertAsync(() => invocations.Should().BeGreaterOrEqualTo(1), TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
@@ -15,13 +15,18 @@ namespace Akka.Persistence.Redis.Tests
 {
     public class RedisTopologyRefresherSpecs : Akka.TestKit.Xunit.TestKit
     {
+        private RedisTopologyRefresher NewRefresher(Func<Task>? refresh = null)
+            => new(refresh ?? (() => Task.CompletedTask), Log);
+
         [Fact]
-        public void IsReplicaRefusal_returns_true_for_canonical_replica_message()
+        public void IsReplicaRefusal_returns_true_for_canonical_replica_message_fallback()
         {
+            // No IConnectionMultiplexer wired up, so the typed check is skipped and
+            // the fallback message match drives the result.
             var ex = new RedisCommandException(
                 "Command cannot be issued to a replica: SET {_EventId-1}.Catalog.MarketSnapshot");
 
-            RedisTopologyRefresher.IsReplicaRefusal(ex).Should().BeTrue();
+            NewRefresher().IsReplicaRefusal(ex).Should().BeTrue();
         }
 
         [Fact]
@@ -31,7 +36,7 @@ namespace Akka.Persistence.Redis.Tests
             // react to it (would cause double-refresh storms).
             var ex = new RedisCommandException("MOVED 1234 192.168.0.5:6379");
 
-            RedisTopologyRefresher.IsReplicaRefusal(ex).Should().BeFalse();
+            NewRefresher().IsReplicaRefusal(ex).Should().BeFalse();
         }
 
         [Fact]
@@ -39,7 +44,7 @@ namespace Akka.Persistence.Redis.Tests
         {
             var ex = new RedisCommandException("WRONGTYPE Operation against a key holding the wrong kind of value");
 
-            RedisTopologyRefresher.IsReplicaRefusal(ex).Should().BeFalse();
+            NewRefresher().IsReplicaRefusal(ex).Should().BeFalse();
         }
 
         [Fact]

--- a/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
+++ b/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.Persistence.Journal;
 using Akka.Util.Internal;
 using StackExchange.Redis;
@@ -27,6 +28,8 @@ namespace Akka.Persistence.Redis.Journal
         private readonly JournalHelper _journalHelper;
         private readonly IConnectionMultiplexer _connection;
         private readonly bool _ownsConnection;
+        private readonly ILoggingAdapter _log;
+        private readonly RedisTopologyRefresher _topology;
 
         public IDatabase Database { get; }
         public bool IsClustered { get; }
@@ -41,6 +44,9 @@ namespace Akka.Persistence.Redis.Journal
             _ownsConnection = resolved.OwnsConnection;
             Database = resolved.Database;
             IsClustered = resolved.IsClustered;
+
+            _log = Context.GetLogger();
+            _topology = RedisTopologyRefresher.Create(_connection, _log);
         }
 
         protected override void PostStop()
@@ -84,11 +90,19 @@ namespace Akka.Persistence.Redis.Journal
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
 
-            await Database.SortedSetRemoveRangeByScoreAsync(
-                _journalHelper.GetJournalKey(persistenceId, IsClustered),
-                -1,
-                toSequenceNr,
-                flags: CommandFlags.DemandMaster);
+            try
+            {
+                await Database.SortedSetRemoveRangeByScoreAsync(
+                    _journalHelper.GetJournalKey(persistenceId, IsClustered),
+                    -1,
+                    toSequenceNr,
+                    flags: CommandFlags.DemandMaster);
+            }
+            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            {
+                _topology.TriggerBackgroundRefresh(persistenceId, nameof(DeleteMessagesToAsync), ex);
+                throw;
+            }
         }
 
         protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
@@ -137,7 +151,18 @@ namespace Akka.Persistence.Redis.Journal
                 aw.HighestSequenceNr,
                 flags: CommandFlags.DemandMaster);
 
-            if (!await transaction.ExecuteAsync())
+            bool transactionSucceeded;
+            try
+            {
+                transactionSucceeded = await transaction.ExecuteAsync();
+            }
+            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            {
+                _topology.TriggerBackgroundRefresh(aw.PersistenceId, nameof(WriteBatchAsync), ex);
+                throw;
+            }
+
+            if (!transactionSucceeded)
                 throw new Exception(
                     $"{nameof(WriteMessagesAsync)}: failed to write {nameof(IPersistentRepresentation)} to redis");
         }

--- a/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
+++ b/src/Akka.Persistence.Redis/Journal/RedisJournal.cs
@@ -98,7 +98,7 @@ namespace Akka.Persistence.Redis.Journal
                     toSequenceNr,
                     flags: CommandFlags.DemandMaster);
             }
-            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            catch (RedisCommandException ex) when (_topology.IsReplicaRefusal(ex))
             {
                 _topology.TriggerBackgroundRefresh(persistenceId, nameof(DeleteMessagesToAsync), ex);
                 throw;
@@ -156,7 +156,7 @@ namespace Akka.Persistence.Redis.Journal
             {
                 transactionSucceeded = await transaction.ExecuteAsync();
             }
-            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            catch (RedisCommandException ex) when (_topology.IsReplicaRefusal(ex))
             {
                 _topology.TriggerBackgroundRefresh(aw.PersistenceId, nameof(WriteBatchAsync), ex);
                 throw;

--- a/src/Akka.Persistence.Redis/RedisTopologyRefresher.cs
+++ b/src/Akka.Persistence.Redis/RedisTopologyRefresher.cs
@@ -5,7 +5,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Event;
@@ -74,7 +73,7 @@ namespace Akka.Persistence.Redis
         {
             if (_connection is not null
                 && ex.Data[RedisServerDataKey] is string endpointString
-                && TryParseEndPoint(endpointString, out var endpoint))
+                && EndPointCollection.TryParse(endpointString) is { } endpoint)
             {
                 try
                 {
@@ -130,28 +129,5 @@ namespace Akka.Persistence.Redis
             }
         }
 
-        // SE.Redis formats endpoints as host:port for DNS/IP, /path for Unix sockets,
-        // or as the raw IPEndPoint ToString shape. Accept what IPEndPoint.TryParse
-        // handles and DnsEndPoint as the fallback for hostnames.
-        private static bool TryParseEndPoint(string raw, out EndPoint endpoint)
-        {
-            if (IPEndPoint.TryParse(raw, out var ipe))
-            {
-                endpoint = ipe;
-                return true;
-            }
-
-            var colon = raw.LastIndexOf(':');
-            if (colon > 0 && colon < raw.Length - 1
-                && int.TryParse(raw.AsSpan(colon + 1), out var port)
-                && port is > 0 and <= 65535)
-            {
-                endpoint = new DnsEndPoint(raw.Substring(0, colon), port);
-                return true;
-            }
-
-            endpoint = null!;
-            return false;
-        }
     }
 }

--- a/src/Akka.Persistence.Redis/RedisTopologyRefresher.cs
+++ b/src/Akka.Persistence.Redis/RedisTopologyRefresher.cs
@@ -1,0 +1,103 @@
+// -----------------------------------------------------------------------
+// <copyright file="RedisTopologyRefresher.cs" company="Petabridge, LLC">
+//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Event;
+using StackExchange.Redis;
+
+#nullable enable
+namespace Akka.Persistence.Redis
+{
+    /// <summary>
+    /// Detects Redis Cluster topology-drift errors that StackExchange.Redis does not
+    /// automatically recover from, and triggers a background topology refresh against
+    /// the multiplexer when one occurs.
+    ///
+    /// SE.Redis 2.6.86+ already auto-refreshes on MOVED redirects (with a 5-second
+    /// internal debounce). The one cluster-failover failure mode it does NOT handle is
+    /// a node refusing a write with the literal server-side message
+    /// "Command cannot be issued to a replica" — surfaced as a plain
+    /// <see cref="RedisCommandException"/> with no typed subtype. That happens when a
+    /// failover has demoted a node to replica but the multiplexer's slot-map cache is
+    /// still routing writes there. This refresher detects that exact case, fires
+    /// <see cref="IConnectionMultiplexer.ConfigureAsync(System.IO.TextWriter?)"/> in
+    /// the background, and lets the journal's circuit breaker handle retry cadence as
+    /// normal.
+    /// </summary>
+    internal sealed class RedisTopologyRefresher
+    {
+        // Literal message produced by SE.Redis when a write reaches a node that is
+        // currently serving as a replica. Stable since SE.Redis 2.6.86. Re-verify on
+        // any SE.Redis package bump.
+        private const string ReplicaRefusalMarker = "Command cannot be issued to a replica";
+
+        private readonly Func<Task> _refresh;
+        private readonly ILoggingAdapter _log;
+
+        // 0 = idle, 1 = refresh already in flight. Suppresses log spam and redundant
+        // refresh dispatches when many concurrent writes all hit the same demoted node.
+        private int _refreshInFlight;
+
+        // Test seam: lets specs inject a Func<Task> in place of the real ConfigureAsync.
+        internal RedisTopologyRefresher(Func<Task> refresh, ILoggingAdapter log)
+        {
+            _refresh = refresh;
+            _log = log;
+        }
+
+        public static RedisTopologyRefresher Create(IConnectionMultiplexer connection, ILoggingAdapter log)
+            => new(() => connection.ConfigureAsync(null), log);
+
+        /// <summary>
+        /// True when the given exception is the "Command cannot be issued to a replica"
+        /// runtime refusal that this refresher reacts to. MOVED, ASK, CROSSSLOT and
+        /// every other <see cref="RedisCommandException"/> shape returns false — they
+        /// either auto-heal in SE.Redis or are user-mode programming errors.
+        /// </summary>
+        public static bool IsReplicaRefusal(RedisCommandException ex)
+            => ex.Message.IndexOf(ReplicaRefusalMarker, StringComparison.Ordinal) >= 0;
+
+        /// <summary>
+        /// Fire-and-forget topology refresh against the multiplexer. Always returns
+        /// synchronously; the caller should rethrow the original exception so the
+        /// journal's circuit breaker handles retry timing normally. The next write
+        /// attempt after the breaker's reset-timeout will see fresh topology.
+        /// </summary>
+        public void TriggerBackgroundRefresh(string persistenceId, string operation, Exception source)
+        {
+            if (Interlocked.CompareExchange(ref _refreshInFlight, 1, 0) != 0)
+                return; // a refresh is already running; suppress duplicate
+
+            _log.Warning(
+                source,
+                "Redis write for persistenceId '{0}' rejected by a node currently serving as a replica during operation '{1}'. Triggering background topology refresh. The next attempt after the circuit breaker's reset-timeout should succeed.",
+                persistenceId,
+                operation);
+
+            _ = RunRefreshAsync();
+        }
+
+        private async Task RunRefreshAsync()
+        {
+            try
+            {
+                await _refresh().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(
+                    ex,
+                    "Background Redis topology refresh failed. StackExchange.Redis will retry on its next periodic configCheckSeconds tick.");
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _refreshInFlight, 0);
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.Redis/RedisTopologyRefresher.cs
+++ b/src/Akka.Persistence.Redis/RedisTopologyRefresher.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Event;
@@ -20,47 +21,76 @@ namespace Akka.Persistence.Redis
     ///
     /// SE.Redis 2.6.86+ already auto-refreshes on MOVED redirects (with a 5-second
     /// internal debounce). The one cluster-failover failure mode it does NOT handle is
-    /// a node refusing a write with the literal server-side message
-    /// "Command cannot be issued to a replica" — surfaced as a plain
-    /// <see cref="RedisCommandException"/> with no typed subtype. That happens when a
-    /// failover has demoted a node to replica but the multiplexer's slot-map cache is
-    /// still routing writes there. This refresher detects that exact case, fires
-    /// <see cref="IConnectionMultiplexer.ConfigureAsync(System.IO.TextWriter?)"/> in
-    /// the background, and lets the journal's circuit breaker handle retry cadence as
-    /// normal.
+    /// a write that lands on a node SE.Redis has just observed serve a
+    /// <c>-READONLY</c> response (i.e. been demoted to replica). SE.Redis flips that
+    /// node's <see cref="IServer.IsReplica"/> flag and then refuses the next write to
+    /// it with a <see cref="RedisCommandException"/>, but does not refresh the cluster
+    /// slot map, so subsequent writes keep routing to the same demoted node until the
+    /// next periodic <c>configCheckSeconds</c> tick.
     /// </summary>
     internal sealed class RedisTopologyRefresher
     {
-        // Literal message produced by SE.Redis when a write reaches a node that is
-        // currently serving as a replica. Stable since SE.Redis 2.6.86. Re-verify on
-        // any SE.Redis package bump.
+        // Fallback message marker for the rare case where IncludeDetailInExceptions
+        // is set to false on the multiplexer's ConfigurationOptions — then SE.Redis
+        // omits the "redis-server" data key, and the only signal left is the message
+        // text. Stable since SE.Redis 2.6.86. Re-verify on any SE.Redis package bump.
         private const string ReplicaRefusalMarker = "Command cannot be issued to a replica";
 
+        // SE.Redis populates Exception.Data with this key for every server-attributed
+        // exception when IncludeDetailInExceptions is true (the default). See
+        // StackExchange.Redis.ExceptionFactory.AddExceptionDetail.
+        private const string RedisServerDataKey = "redis-server";
+
         private readonly Func<Task> _refresh;
+        private readonly IConnectionMultiplexer? _connection;
         private readonly ILoggingAdapter _log;
 
         // 0 = idle, 1 = refresh already in flight. Suppresses log spam and redundant
         // refresh dispatches when many concurrent writes all hit the same demoted node.
         private int _refreshInFlight;
 
-        // Test seam: lets specs inject a Func<Task> in place of the real ConfigureAsync.
-        internal RedisTopologyRefresher(Func<Task> refresh, ILoggingAdapter log)
+        // Test seam: lets specs inject a Func<Task> in place of the real ConfigureAsync
+        // and an optional multiplexer for IsReplicaRefusal's typed check.
+        internal RedisTopologyRefresher(Func<Task> refresh, ILoggingAdapter log, IConnectionMultiplexer? connection = null)
         {
             _refresh = refresh;
             _log = log;
+            _connection = connection;
         }
 
         public static RedisTopologyRefresher Create(IConnectionMultiplexer connection, ILoggingAdapter log)
-            => new(() => connection.ConfigureAsync(null), log);
+            => new(() => connection.ConfigureAsync(null), log, connection);
 
         /// <summary>
-        /// True when the given exception is the "Command cannot be issued to a replica"
-        /// runtime refusal that this refresher reacts to. MOVED, ASK, CROSSSLOT and
-        /// every other <see cref="RedisCommandException"/> shape returns false — they
-        /// either auto-heal in SE.Redis or are user-mode programming errors.
+        /// True when this exception was produced because a write was routed to a node
+        /// that is currently flagged as a replica. Primary signal is the typed check:
+        /// <see cref="Exception.Data"/>[<c>"redis-server"</c>] identifies the endpoint
+        /// that refused, and <see cref="IServer.IsReplica"/> tells us its actual state.
+        /// Falls back to the literal SE.Redis message text only when
+        /// <c>ConfigurationOptions.IncludeDetailInExceptions</c> is false (the data
+        /// dictionary is then empty).
         /// </summary>
-        public static bool IsReplicaRefusal(RedisCommandException ex)
-            => ex.Message.IndexOf(ReplicaRefusalMarker, StringComparison.Ordinal) >= 0;
+        public bool IsReplicaRefusal(RedisCommandException ex)
+        {
+            if (_connection is not null
+                && ex.Data[RedisServerDataKey] is string endpointString
+                && TryParseEndPoint(endpointString, out var endpoint))
+            {
+                try
+                {
+                    var server = _connection.GetServer(endpoint);
+                    if (server.IsReplica)
+                        return true;
+                }
+                catch
+                {
+                    // Endpoint not recognized by the multiplexer (e.g. stale entry).
+                    // Fall through to the message-text fallback.
+                }
+            }
+
+            return ex.Message.IndexOf(ReplicaRefusalMarker, StringComparison.Ordinal) >= 0;
+        }
 
         /// <summary>
         /// Fire-and-forget topology refresh against the multiplexer. Always returns
@@ -98,6 +128,30 @@ namespace Akka.Persistence.Redis
             {
                 Interlocked.Exchange(ref _refreshInFlight, 0);
             }
+        }
+
+        // SE.Redis formats endpoints as host:port for DNS/IP, /path for Unix sockets,
+        // or as the raw IPEndPoint ToString shape. Accept what IPEndPoint.TryParse
+        // handles and DnsEndPoint as the fallback for hostnames.
+        private static bool TryParseEndPoint(string raw, out EndPoint endpoint)
+        {
+            if (IPEndPoint.TryParse(raw, out var ipe))
+            {
+                endpoint = ipe;
+                return true;
+            }
+
+            var colon = raw.LastIndexOf(':');
+            if (colon > 0 && colon < raw.Length - 1
+                && int.TryParse(raw.AsSpan(colon + 1), out var port)
+                && port is > 0 and <= 65535)
+            {
+                endpoint = new DnsEndPoint(raw.Substring(0, colon), port);
+                return true;
+            }
+
+            endpoint = null!;
+            return false;
         }
     }
 }

--- a/src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs
+++ b/src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.Persistence.Snapshot;
 using StackExchange.Redis;
 
@@ -24,6 +25,8 @@ namespace Akka.Persistence.Redis.Snapshot
         private readonly ActorSystem _system;
         private readonly IConnectionMultiplexer _connection;
         private readonly bool _ownsConnection;
+        private readonly ILoggingAdapter _log;
+        private readonly RedisTopologyRefresher _topology;
 
         public IDatabase Database { get; }
         public bool IsClustered { get; }
@@ -38,6 +41,9 @@ namespace Akka.Persistence.Redis.Snapshot
             _ownsConnection = resolved.OwnsConnection;
             Database = resolved.Database;
             IsClustered = resolved.IsClustered;
+
+            _log = Context.GetLogger();
+            _topology = RedisTopologyRefresher.Create(_connection, _log);
         }
 
         protected override void PostStop()
@@ -70,16 +76,24 @@ namespace Akka.Persistence.Redis.Snapshot
             return found;
         }
 
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
+        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
             // Redis driver does not support cancellation token
             cancellationToken.ThrowIfCancellationRequested();
 
-            return Database.SortedSetAddAsync(
-                GetSnapshotKey(metadata.PersistenceId, IsClustered),
-                PersistentToBytes(metadata, snapshot),
-                metadata.SequenceNr,
-                flags: CommandFlags.DemandMaster);
+            try
+            {
+                await Database.SortedSetAddAsync(
+                    GetSnapshotKey(metadata.PersistenceId, IsClustered),
+                    PersistentToBytes(metadata, snapshot),
+                    metadata.SequenceNr,
+                    flags: CommandFlags.DemandMaster);
+            }
+            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            {
+                _topology.TriggerBackgroundRefresh(metadata.PersistenceId, nameof(SaveAsync), ex);
+                throw;
+            }
         }
 
         protected override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
@@ -89,11 +103,19 @@ namespace Akka.Persistence.Redis.Snapshot
 
             if(metadata.Timestamp == DateTime.MinValue)
             {
-                await Database.SortedSetRemoveRangeByScoreAsync(
-                    GetSnapshotKey(metadata.PersistenceId, IsClustered),
-                    metadata.SequenceNr,
-                    metadata.SequenceNr,
-                    flags: CommandFlags.DemandMaster);
+                try
+                {
+                    await Database.SortedSetRemoveRangeByScoreAsync(
+                        GetSnapshotKey(metadata.PersistenceId, IsClustered),
+                        metadata.SequenceNr,
+                        metadata.SequenceNr,
+                        flags: CommandFlags.DemandMaster);
+                }
+                catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+                {
+                    _topology.TriggerBackgroundRefresh(metadata.PersistenceId, nameof(DeleteAsync), ex);
+                    throw;
+                }
                 return;
             }
 
@@ -115,7 +137,15 @@ namespace Akka.Persistence.Redis.Snapshot
                     flags: CommandFlags.DemandMaster))
                 .ToArray();
 
-            await Task.WhenAll(found);
+            try
+            {
+                await Task.WhenAll(found);
+            }
+            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            {
+                _topology.TriggerBackgroundRefresh(metadata.PersistenceId, nameof(DeleteAsync), ex);
+                throw;
+            }
         }
 
         protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
@@ -141,7 +171,15 @@ namespace Akka.Persistence.Redis.Snapshot
                     flags: CommandFlags.DemandMaster))
                 .ToArray();
 
-            await Task.WhenAll(found);
+            try
+            {
+                await Task.WhenAll(found);
+            }
+            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            {
+                _topology.TriggerBackgroundRefresh(persistenceId, nameof(DeleteAsync), ex);
+                throw;
+            }
         }
 
         private byte[] PersistentToBytes(SnapshotMetadata metadata, object snapshot)

--- a/src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs
+++ b/src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs
@@ -89,7 +89,7 @@ namespace Akka.Persistence.Redis.Snapshot
                     metadata.SequenceNr,
                     flags: CommandFlags.DemandMaster);
             }
-            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            catch (RedisCommandException ex) when (_topology.IsReplicaRefusal(ex))
             {
                 _topology.TriggerBackgroundRefresh(metadata.PersistenceId, nameof(SaveAsync), ex);
                 throw;
@@ -111,7 +111,7 @@ namespace Akka.Persistence.Redis.Snapshot
                         metadata.SequenceNr,
                         flags: CommandFlags.DemandMaster);
                 }
-                catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+                catch (RedisCommandException ex) when (_topology.IsReplicaRefusal(ex))
                 {
                     _topology.TriggerBackgroundRefresh(metadata.PersistenceId, nameof(DeleteAsync), ex);
                     throw;
@@ -141,7 +141,7 @@ namespace Akka.Persistence.Redis.Snapshot
             {
                 await Task.WhenAll(found);
             }
-            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            catch (RedisCommandException ex) when (_topology.IsReplicaRefusal(ex))
             {
                 _topology.TriggerBackgroundRefresh(metadata.PersistenceId, nameof(DeleteAsync), ex);
                 throw;
@@ -175,7 +175,7 @@ namespace Akka.Persistence.Redis.Snapshot
             {
                 await Task.WhenAll(found);
             }
-            catch (RedisCommandException ex) when (RedisTopologyRefresher.IsReplicaRefusal(ex))
+            catch (RedisCommandException ex) when (_topology.IsReplicaRefusal(ex))
             {
                 _topology.TriggerBackgroundRefresh(persistenceId, nameof(DeleteAsync), ex);
                 throw;

--- a/src/Akka.Persistence.Redis/reference.conf
+++ b/src/Akka.Persistence.Redis/reference.conf
@@ -14,11 +14,30 @@
       # dispatcher used to drive journal actor
       plugin-dispatcher = "akka.actor.default-dispatcher"
 
-      # Redis journals key prefixes. Leave it for default or change it to appropriate value. 
+      # Redis journals key prefixes. Leave it for default or change it to appropriate value.
       # WARNING: don't change it on production instances.
       key-prefix = ""
+
+      # --------------------------------------------------------------------------
+      # Recommended Redis Cluster tuning (NOT defaults; copy into your application
+      # HOCON if you are running against Redis Cluster).
+      #
+      # Aggressive call-timeout values (e.g. 120s) AMPLIFY brief cluster blips into
+      # multi-minute outages by holding hundreds of in-flight recoveries open.
+      # 10s pairs with the recommended SE.Redis sync/asyncTimeout of 5000ms.
+      # See README.md > "Running against Redis Cluster" for the full guidance.
+      # --------------------------------------------------------------------------
+      # circuit-breaker {
+      #   call-timeout  = 10s
+      #   reset-timeout = 30s
+      #   max-failures  = 10
+      # }
+      #
+      # Also consider lowering this at the akka.persistence root for sharded
+      # deployments — 64 (small) or 128 (large) instead of higher values:
+      # akka.persistence.max-concurrent-recoveries = 64
     }
-  }  
+  }
 
   snapshot-store {
     redis {
@@ -36,6 +55,17 @@
       plugin-dispatcher = "akka.actor.default-dispatcher"
 
       key-prefix = ""
+
+      # --------------------------------------------------------------------------
+      # Recommended Redis Cluster tuning (NOT defaults; copy into your application
+      # HOCON if you are running against Redis Cluster). Same guidance as the
+      # journal block above — see README.md > "Running against Redis Cluster".
+      # --------------------------------------------------------------------------
+      # circuit-breaker {
+      #   call-timeout  = 10s
+      #   reset-timeout = 30s
+      #   max-failures  = 10
+      # }
     }
   }
 }


### PR DESCRIPTION
## Summary

This pull request adds automatic handling for one specific failure mode that occurs after a Redis Cluster failover. Before this change, a brief cluster failover could cause minutes of failed writes. After this change, writes recover within one circuit-breaker reset cycle.

## What the problem is

When a Redis Cluster fails over, the cluster reshuffles which node owns which hash slot. One node is demoted from primary to replica, and another node takes over. During a short window after the failover, the StackExchange.Redis client's internal slot map is stale: it still thinks the old primary is the primary, so it routes writes to it. The demoted node refuses with a server-side error message that reads "Command cannot be issued to a replica."

StackExchange.Redis recognizes and handles many cluster errors on its own. When it sees a `MOVED` response, for example, it refreshes its slot map automatically, with a 5-second internal debounce. That behavior has been built into the client since version 2.6.86. But the replica-refusal error is not one of the cases it handles. Until the next scheduled topology check (once a minute by default), every write the client sends to the demoted node fails.

Customers using aggressive Akka.Persistence settings amplify the problem. A `call-timeout` of 120 seconds combined with hundreds of concurrent recoveries can turn a 30-second cluster blip into 30 minutes of downtime, because each in-flight recovery takes two minutes to fail and 512 of them pile up at once.

## What this change does

When the journal or snapshot store sends a write and gets back the replica-refusal error, the plugin now:

1. Triggers a topology refresh on the multiplexer in the background. The call site does not wait for it.
2. Logs a warning, so operators can see that topology drift occurred.
3. Rethrows the original exception, so the journal's existing circuit breaker handles retry timing exactly as before.

By the time the circuit breaker's reset-timeout elapses (the README recommends 30 seconds), the refresh has completed and the next write attempt sees the correct topology. The fix is applied only at write and delete sites. Reads are not wrapped, because replicas serve reads correctly.

## What is in this pull request

### New files

- `src/Akka.Persistence.Redis/RedisTopologyRefresher.cs`. An internal helper class that detects the replica-refusal message and dispatches the background refresh. It uses an `Interlocked` flag to deduplicate simultaneous triggers, so a flood of failed writes produces exactly one refresh call and one warning log line, not one per failure.
- `src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs`. Eight unit tests covering the predicate, single dispatch, deduplication of concurrent triggers, flag reset after a refresh completes, warning logging when the refresh task itself faults, and clean handling of a synchronous exception inside the refresh callable.

### Modified files

- `src/Akka.Persistence.Redis/Journal/RedisJournal.cs`. Adds inline catch blocks at two sites: `DeleteMessagesToAsync` and the `transaction.ExecuteAsync` call inside `WriteBatchAsync`.
- `src/Akka.Persistence.Redis/Snapshot/RedisSnapshotStore.cs`. Adds inline catch blocks at four sites: `SaveAsync` and three `DeleteAsync` paths.
- `src/Akka.Persistence.Redis/reference.conf`. Adds commented circuit-breaker tuning guidance under both the journal and snapshot store sections. No default values change.
- `README.md`. Adds a new section titled "Running against Redis Cluster," placed between the command-availability table and the Akka.Hosting Integration section.

The new documentation section covers:

- A recommended connection string for clustered deployments, with each setting explained.
- Recommended Akka.Persistence circuit-breaker settings and recovery-concurrency values, including the reasoning for why a 120-second `call-timeout` is harmful rather than safe.
- An explicit rule that the application's `Ask` timeout must always be larger than the journal's `call-timeout`. The rule of thumb given is `Ask >= call-timeout * max-failures * 1.5`.
- A summary of which cluster-failover failure modes StackExchange.Redis handles automatically and which the plugin now handles.
- A pointer to `WithRedisPersistence(multiplexer:)` for cases that need full programmatic control over `ConfigurationOptions`.

## Test results

- Unit tests: 149 passed, 0 failed, 1 skipped.
- Cluster integration tests: 89 passed, 0 failed, 1 skipped.

No regressions in either suite.

## Design notes

The original plan called for a broad catch over `MOVED`, `ASK`, `NOREPLICAS`, `CLUSTERDOWN`, and replica refusals. We decompiled StackExchange.Redis 2.12.14 and confirmed that the client already auto-refreshes on `MOVED` (this has been the case since 2.6.86). Adding a second refresh trigger on top of that would cause duplicate dispatches and obscure the client's own behavior, so this pull request catches only the one message the client genuinely does not handle.

The six catch blocks in the journal and snapshot store are written inline rather than extracted into a shared helper. The `catch when (RedisTopologyRefresher.IsReplicaRefusal(ex))` filter describes each method's failure contract at the call site. Pulling it into a helper would hide that contract behind a lambda, and the apparent duplication is syntactic rather than semantic, because each site wraps a different Redis operation.

## Out of scope

- Subscribing to multiplexer events (`ConnectionFailed`, `ConnectionRestored`, `ConfigurationChanged`, `HashSlotMoved`) for operator visibility. This is worth doing in a follow-up, but the right shape is OpenTelemetry counters and activities rather than ad hoc warning logs, and that design has not been settled.
- A richer cluster-failover test harness. The current single-container cluster fixture cannot demote a primary mid-write, so end-to-end coverage of the replica-refusal path would require either a multi-container fixture or in-container process control.

## Test plan

- [x] `dotnet build -c Release` succeeds with no errors.
- [x] `dotnet test src/Akka.Persistence.Redis.Tests` passes (149 of 150, one skipped).
- [x] `dotnet test src/Akka.Persistence.Redis.Cluster.Tests` passes (89 of 90, one skipped).
- [ ] Continuous integration passes.
- [ ] Manual verification against a real Redis Cluster: trigger a failover, observe the new warning log, and confirm that the next circuit-breaker retry succeeds.
