### PR TITLE
chore: release 1.5.68

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,33 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.Redis</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageReleaseNotes>* Upgraded to [Akka.NET 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
-* Upgraded to [Akka.Hosting 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)</PackageReleaseNotes>
+    <PackageReleaseNotes>This is the stable release of the post-1.5.67 Redis hardening work.
+
+**Behavior Changes / Compatibility Notes**
+
+* Removed the legacy query subscriber notification protocol (`ISubscriptionCommand`, `SubscribeNewEvents`, and `NewEventAppended`). Live persistence queries now rely exclusively on polling via `akka.persistence.query.journal.redis.refresh-interval`. This removes a dead actor-local optimization that could leak subscribers and race with journal writes. Users that need lower live-query latency can reduce the Redis query `refresh-interval`.
+* Redis journal and snapshot-store connections are now created during plugin actor construction instead of lazily on first database access. This fixes a `ConnectionMultiplexer` lifecycle leak and allows plugin-owned connections to be disposed when the actor stops, but connection failures may now surface earlier during plugin startup.
+* Akka.Hosting Redis configuration now validates missing connection sources earlier. Each configured Redis journal or snapshot store must have either a HOCON connection string or a matching `RedisConnectionMultiplexerSetup` entry.
+
+**Improvements**
+
+* Added `WithAzureRedisPersistence(...)` for Azure Managed Redis and Azure Cache for Redis using Entra ID / Managed Identity authentication. The helper configures TLS, RESP3, `SslHost`, and token authentication via `Microsoft.Azure.StackExchangeRedis`.
+* Added plugin-scoped `RedisConnectionMultiplexerSetup` support for caller-supplied multiplexers and multiplexer factories. Setup entries are keyed by Redis plugin id, so one Redis plugin's injected connection source does not override another plugin's HOCON connection string.
+* Added explicit Redis connection ownership semantics via `RedisConnectionOwnership`: caller-owned, plugin-owned, and actor-system-owned.
+* Updated Redis health checks so setup-backed plugins reuse the configured connection source, while HOCON-only plugins open a temporary multiplexer for the probe and dispose it after `PING`.
+* Fixed snapshot-only Akka.Hosting configuration so Redis default HOCON is still loaded when only the snapshot store is configured.
+* Fixed `DeferAsync` with an empty write batch, which previously could throw from `ContinueWhenAll`.
+* Added `CommandFlags.DemandMaster` to Redis write operations as defense-in-depth for primary-only writes.
+* Removed the `ConnectionMultiplexer` leak in journal and snapshot actors by tracking connection ownership and disposing plugin-owned connections from `PostStop`.
+* Reworked Redis test fixtures to use Testcontainers and hardened cluster readiness / CI failure behavior.
+* Added automatic Redis Cluster topology refresh on the "Command cannot be issued to a replica" error that surfaces after a failover demotes a primary. The journal and snapshot store catch this case, fire `IConnectionMultiplexer.ConfigureAsync()` in the background, and rethrow so the existing circuit breaker handles retry timing. Detection uses `IServer.IsReplica` against the endpoint in `Exception.Data["redis-server"]`, with the literal message as a fallback when `ConfigurationOptions.IncludeDetailInExceptions = false`.
+* Added a new "Running against Redis Cluster" section to `README.md` covering the recommended SE.Redis connection string, Akka.Persistence circuit-breaker tuning, the `Ask` timeout vs `call-timeout` rule, and which cluster-failover failure modes are handled by StackExchange.Redis vs the plugin.
+* Added commented circuit-breaker tuning guidance under the journal and snapshot-store sections of `reference.conf`. No HOCON defaults change.
+
+**Dependencies**
+
+* Upgraded `StackExchange.Redis` to 2.12.14.
+* Added `Microsoft.Azure.StackExchangeRedis` 3.3.1 and `Azure.Identity` 1.17.1 to `Akka.Persistence.Redis.Hosting`.
+* Updated test/build dependencies including `Microsoft.NET.Test.Sdk`, `coverlet.collector`, `Testcontainers`, and `Microsoft.SourceLink.GitHub`.</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-#### 1.5.68-beta1 May 13th 2026 ####
+#### 1.5.68 June 1st 2026 ####
 
-This is a prerelease of the post-1.5.67 Redis hardening work. Customers running against Redis Cluster are the primary audience: try this in staging, validate failover recovery against your topology, and report back before the stable 1.5.68 ships.
+This is the stable release of the post-1.5.67 Redis hardening work.
 
 **Behavior Changes / Compatibility Notes**
 


### PR DESCRIPTION
Prepare Akka.Persistence.Redis 1.5.68 stable release.

- Update `PackageReleaseNotes` to point to 1.5.68 stable links
- Run `build.ps1` to update version and release notes metadata
- Update `RELEASE_NOTES.md` to mark 1.5.68 as stable (not prerelease)