### PR TITLE
Remove FluentAssertions dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,9 +26,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="JetBrains.dotMemoryUnit" Version="3.2.20220510" />

--- a/src/Akka.Persistence.Redis.Cluster.Tests/Akka.Persistence.Redis.Cluster.Tests.csproj
+++ b/src/Akka.Persistence.Redis.Cluster.Tests/Akka.Persistence.Redis.Cluster.Tests.csproj
@@ -19,9 +19,7 @@
         <ProjectReference Include="..\Akka.Persistence.Redis\Akka.Persistence.Redis.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <ItemGroup>        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Testcontainers" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/Akka.Persistence.Redis.Cluster.Tests/RedisJournalDefaultDatabaseSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Tests/RedisJournalDefaultDatabaseSpec.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Net;
 using Akka.Configuration;
 using Akka.Persistence.TCK.Journal;
-using FluentAssertions;
 using StackExchange.Redis;
 using Xunit;
 
@@ -95,7 +94,7 @@ namespace Akka.Persistence.Redis.Cluster.Tests
             // expected CV is ~1/sqrt(n*p) — at n=10000 with k=3 buckets that is ~0.025; the
             // 99.9% upper bound is well below 0.10. A real distribution failure (one bucket
             // capturing >50% of keys) would push CV well above 0.10.
-            coefficientOfVariation.Should().BeLessThan(0.10);
+            Assert.True((coefficientOfVariation) < (0.10));
         }
 
         private double StandardDeviation(int[] values)

--- a/src/Akka.Persistence.Redis.Cluster.Tests/RedisJournalSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Tests/RedisJournalSpec.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Net;
 using Akka.Configuration;
 using Akka.Persistence.TCK.Journal;
-using FluentAssertions;
 using StackExchange.Redis;
 using Xunit;
 
@@ -94,7 +93,7 @@ namespace Akka.Persistence.Redis.Cluster.Tests
             // expected CV is ~1/sqrt(n*p) — at n=10000 with k=3 buckets that is ~0.025; the
             // 99.9% upper bound is well below 0.10. A real distribution failure (one bucket
             // capturing >50% of keys) would push CV well above 0.10.
-            coefficientOfVariation.Should().BeLessThan(0.10);
+            Assert.True((coefficientOfVariation) < (0.10));
         }
 
         private double StandardDeviation(int[] values)

--- a/src/Akka.Persistence.Redis.Cluster.Tests/RedisSettingsSpec.cs
+++ b/src/Akka.Persistence.Redis.Cluster.Tests/RedisSettingsSpec.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="RedisSettingsSpec.cs" company="Akka.NET Project">
-//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-// -----------------------------------------------------------------------
-
-using FluentAssertions;
-using Xunit;
+﻿using Xunit;
 
 namespace Akka.Persistence.Redis.Cluster.Tests
 {
@@ -16,9 +9,9 @@ namespace Akka.Persistence.Redis.Cluster.Tests
         {
             var redisPersistence = RedisPersistence.Get(Sys);
 
-            redisPersistence.JournalSettings.ConfigurationString.Should().Be(string.Empty);
-            redisPersistence.JournalSettings.Database.Should().Be(0);
-            redisPersistence.JournalSettings.KeyPrefix.Should().Be(string.Empty);
+            Assert.Equal(string.Empty, redisPersistence.JournalSettings.ConfigurationString);
+            Assert.Equal(0, redisPersistence.JournalSettings.Database);
+            Assert.Equal(string.Empty, redisPersistence.JournalSettings.KeyPrefix);
         }
 
         [Fact]
@@ -26,9 +19,9 @@ namespace Akka.Persistence.Redis.Cluster.Tests
         {
             var redisPersistence = RedisPersistence.Get(Sys);
 
-            redisPersistence.SnapshotStoreSettings.ConfigurationString.Should().Be(string.Empty);
-            redisPersistence.SnapshotStoreSettings.Database.Should().Be(0);
-            redisPersistence.SnapshotStoreSettings.KeyPrefix.Should().Be(string.Empty);
+            Assert.Equal(string.Empty, redisPersistence.SnapshotStoreSettings.ConfigurationString);
+            Assert.Equal(0, redisPersistence.SnapshotStoreSettings.Database);
+            Assert.Equal(string.Empty, redisPersistence.SnapshotStoreSettings.KeyPrefix);
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
+++ b/src/Akka.Persistence.Redis.Tests/Akka.Persistence.Redis.Tests.csproj
@@ -15,9 +15,7 @@
     <ProjectReference Include="..\Akka.Persistence.Redis\Akka.Persistence.Redis.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="Akka.Hosting.TestKit" />
+  <ItemGroup>    <PackageReference Include="Akka.Hosting.TestKit" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Testcontainers" />

--- a/src/Akka.Persistence.Redis.Tests/Hosting/AzureRedisHostingExtensionsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/AzureRedisHostingExtensionsSpec.cs
@@ -9,7 +9,6 @@ using Akka.Hosting;
 using Akka.Persistence.Hosting;
 using Akka.Persistence.Redis;
 using Akka.Persistence.Redis.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -36,7 +35,7 @@ public class AzureRedisHostingExtensionsSpec
     [InlineData("redis.example.com:6379", false)]
     public void IsAzureRedisHost_should_match_only_Azure_managed_redis_suffixes(string connectionString, bool expected)
     {
-        AzureRedisHostingExtensions.IsAzureRedisHost(connectionString).Should().Be(expected);
+        Assert.Equal(expected, AzureRedisHostingExtensions.IsAzureRedisHost(connectionString));
     }
 
     [Fact]
@@ -44,9 +43,8 @@ public class AzureRedisHostingExtensionsSpec
     {
         // Treat an explicit password as an opt-out from token-credential auth, regardless
         // of host suffix. The user clearly wants connection-string auth in that case.
-        AzureRedisHostingExtensions.IsAzureRedisHost(
-            "your-redis.swedencentral.redis.azure.net:10000,password=secret")
-            .Should().BeFalse();
+        Assert.False(AzureRedisHostingExtensions.IsAzureRedisHost(
+            "your-redis.swedencentral.redis.azure.net:10000,password=secret"));
     }
 
     [Fact]
@@ -56,8 +54,7 @@ public class AzureRedisHostingExtensionsSpec
         // and must never throw. A malformed string falls through as `false`; the actual
         // configuration error will surface later from ConnectionMultiplexer.Connect with
         // a clearer message.
-        AzureRedisHostingExtensions.IsAzureRedisHost("definitely::not::a::valid::connection::string")
-            .Should().BeFalse();
+        Assert.False(AzureRedisHostingExtensions.IsAzureRedisHost("definitely::not::a::valid::connection::string"));
     }
 
     [Fact]
@@ -68,12 +65,11 @@ public class AzureRedisHostingExtensionsSpec
         builder.WithAzureRedisPersistence("your-redis.swedencentral.redis.azure.net:10000");
 
         var setup = builder.Setups.OfType<RedisConnectionMultiplexerSetup>().FirstOrDefault();
-        setup.Should().NotBeNull(
-            "WithAzureRedisPersistence must register a RedisConnectionMultiplexerSetup for the Azure-built factory");
-        setup!.TryGetSource("akka.persistence.journal.redis", out var journalSource).Should().BeTrue();
-        journalSource.Ownership.Should().Be(RedisConnectionOwnership.ActorSystemOwned);
-        setup.TryGetSource("akka.persistence.snapshot-store.redis", out var snapshotSource).Should().BeTrue();
-        snapshotSource.Ownership.Should().Be(RedisConnectionOwnership.ActorSystemOwned);
+        Assert.NotNull(setup);
+        Assert.True(setup!.TryGetSource("akka.persistence.journal.redis", out var journalSource));
+        Assert.Equal(RedisConnectionOwnership.ActorSystemOwned, journalSource.Ownership);
+        Assert.True(setup.TryGetSource("akka.persistence.snapshot-store.redis", out var snapshotSource));
+        Assert.Equal(RedisConnectionOwnership.ActorSystemOwned, snapshotSource.Ownership);
     }
 
     [Fact]
@@ -84,8 +80,7 @@ public class AzureRedisHostingExtensionsSpec
         // localhost falls through to the plain HOCON connection-string path; no Setup.
         builder.WithAzureRedisPersistence("localhost:6379");
 
-        builder.Setups.OfType<RedisConnectionMultiplexerSetup>().Should().BeEmpty(
-            "non-Azure hosts must use the HOCON connection-string path, not the factory path");
+        Assert.Empty(builder.Setups.OfType<RedisConnectionMultiplexerSetup>() ?? []);
     }
 
     [Fact]
@@ -102,10 +97,9 @@ public class AzureRedisHostingExtensionsSpec
                 isDefaultPlugin: false);
 
         var setup = builder.Setups.OfType<RedisConnectionMultiplexerSetup>().Single();
-        setup.TryGetSource("akka.persistence.journal.redis", out _).Should().BeTrue();
-        setup.TryGetSource("akka.persistence.snapshot-store.redis", out _).Should().BeTrue();
-        setup.TryGetSource("akka.persistence.journal.events", out _).Should().BeFalse(
-            "a source registered for the default Azure plugin must not override a separate HOCON-backed plugin");
+        Assert.True(setup.TryGetSource("akka.persistence.journal.redis", out _));
+        Assert.True(setup.TryGetSource("akka.persistence.snapshot-store.redis", out _));
+        Assert.False(setup.TryGetSource("akka.persistence.journal.events", out _));
     }
 
     [Fact]
@@ -118,8 +112,8 @@ public class AzureRedisHostingExtensionsSpec
             mode: PersistenceMode.Journal);
 
         var setup = builder.Setups.OfType<RedisConnectionMultiplexerSetup>().Single();
-        setup.TryGetSource("akka.persistence.journal.redis", out _).Should().BeTrue();
-        setup.TryGetSource("akka.persistence.snapshot-store.redis", out _).Should().BeFalse();
+        Assert.True(setup.TryGetSource("akka.persistence.journal.redis", out _));
+        Assert.False(setup.TryGetSource("akka.persistence.snapshot-store.redis", out _));
     }
 
     [Fact]
@@ -127,7 +121,7 @@ public class AzureRedisHostingExtensionsSpec
     {
         var builder = NewBuilder();
         var act = () => builder.WithAzureRedisPersistence(string.Empty);
-        act.Should().Throw<System.ArgumentException>()
+        Assert.Throws<System.ArgumentException>(act)
             .WithMessage("*connection string*", "*").Where(ex => ex.ParamName == "connectionString");
     }
 

--- a/src/Akka.Persistence.Redis.Tests/Hosting/AzureRedisHostingExtensionsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/AzureRedisHostingExtensionsSpec.cs
@@ -121,8 +121,9 @@ public class AzureRedisHostingExtensionsSpec
     {
         var builder = NewBuilder();
         var act = () => builder.WithAzureRedisPersistence(string.Empty);
-        Assert.Throws<System.ArgumentException>(act)
-            .WithMessage("*connection string*", "*").Where(ex => ex.ParamName == "connectionString");
+        var ex = Assert.Throws<System.ArgumentException>(act);
+        Assert.Contains("connection string", ex.Message);
+        Assert.Equal("connectionString", ex.ParamName);
     }
 
     private static AkkaConfigurationBuilder NewBuilder()

--- a/src/Akka.Persistence.Redis.Tests/Hosting/ConnectionInjectionConfigurationSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/ConnectionInjectionConfigurationSpec.cs
@@ -112,8 +112,8 @@ public class ConnectionInjectionConfigurationSpec
 
         var act = () => builder.WithRedisPersistence(journalOptions, snapshotOptions: null);
 
-        Assert.Throws<ArgumentException>(act)
-            .WithMessage("*requires a connection source*");
+        var ex = Assert.Throws<ArgumentException>(act);
+        Assert.Contains("requires a connection source", ex.Message);
     }
 
     [Fact]
@@ -130,8 +130,8 @@ public class ConnectionInjectionConfigurationSpec
             FakeFactory(),
             RedisConnectionOwnership.PluginOwned);
 
-        Assert.Throws<InvalidOperationException>(act)
-            .WithMessage("*akka.persistence.journal.redis*");
+        var ex = Assert.Throws<InvalidOperationException>(act);
+        Assert.Contains("akka.persistence.journal.redis", ex.Message);
     }
 
     private static AkkaConfigurationBuilder NewBuilder()

--- a/src/Akka.Persistence.Redis.Tests/Hosting/ConnectionInjectionConfigurationSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/ConnectionInjectionConfigurationSpec.cs
@@ -11,7 +11,6 @@ using Akka.Hosting;
 using Akka.Persistence.Hosting;
 using Akka.Persistence.Redis;
 using Akka.Persistence.Redis.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 using Xunit;
@@ -28,7 +27,7 @@ public class ConnectionInjectionConfigurationSpec
 
         builder.WithRedisPersistence("localhost:6379");
 
-        builder.Setups.OfType<RedisConnectionMultiplexerSetup>().Should().BeEmpty();
+        Assert.Empty(builder.Setups.OfType<RedisConnectionMultiplexerSetup>() ?? []);
     }
 
     [Theory]
@@ -51,19 +50,19 @@ public class ConnectionInjectionConfigurationSpec
             isDefaultPlugin: false);
 
         var setup = builder.Setups.OfType<RedisConnectionMultiplexerSetup>().Single();
-        setup.TryGetSource("akka.persistence.journal.custom", out var journalSource).Should().Be(expectJournal);
-        setup.TryGetSource("akka.persistence.snapshot-store.custom", out var snapshotSource).Should().Be(expectSnapshot);
+        Assert.Equal(expectJournal, setup.TryGetSource("akka.persistence.journal.custom", out var journalSource));
+        Assert.Equal(expectSnapshot, setup.TryGetSource("akka.persistence.snapshot-store.custom", out var snapshotSource));
 
         if (expectJournal)
         {
-            journalSource!.Ownership.Should().Be(RedisConnectionOwnership.PluginOwned);
-            journalSource.Factory.Should().BeSameAs(factory);
+            Assert.Equal(RedisConnectionOwnership.PluginOwned, journalSource!.Ownership);
+            Assert.Same(factory, journalSource.Factory);
         }
 
         if (expectSnapshot)
         {
-            snapshotSource!.Ownership.Should().Be(RedisConnectionOwnership.PluginOwned);
-            snapshotSource.Factory.Should().BeSameAs(factory);
+            Assert.Equal(RedisConnectionOwnership.PluginOwned, snapshotSource!.Ownership);
+            Assert.Same(factory, snapshotSource.Factory);
         }
     }
 
@@ -81,10 +80,10 @@ public class ConnectionInjectionConfigurationSpec
             isDefaultPlugin: false);
 
         var setup = builder.Setups.OfType<RedisConnectionMultiplexerSetup>().Single();
-        setup.TryGetSource("akka.persistence.journal.factory", out var source).Should().BeTrue();
-        source!.Ownership.Should().Be(RedisConnectionOwnership.CallerOwned);
-        source.Factory.Should().BeSameAs(factory);
-        setup.TryGetSource("akka.persistence.snapshot-store.factory", out _).Should().BeFalse();
+        Assert.True(setup.TryGetSource("akka.persistence.journal.factory", out var source));
+        Assert.Equal(RedisConnectionOwnership.CallerOwned, source!.Ownership);
+        Assert.Same(factory, source.Factory);
+        Assert.False(setup.TryGetSource("akka.persistence.snapshot-store.factory", out _));
     }
 
     [Fact]
@@ -102,7 +101,7 @@ public class ConnectionInjectionConfigurationSpec
 
         var act = () => builder.WithRedisPersistence(journalOptions, snapshotOptions: null);
 
-        act.Should().NotThrow();
+        Assert.Null(Record.Exception(act));
     }
 
     [Fact]
@@ -113,7 +112,7 @@ public class ConnectionInjectionConfigurationSpec
 
         var act = () => builder.WithRedisPersistence(journalOptions, snapshotOptions: null);
 
-        act.Should().Throw<ArgumentException>()
+        Assert.Throws<ArgumentException>(act)
             .WithMessage("*requires a connection source*");
     }
 
@@ -131,7 +130,7 @@ public class ConnectionInjectionConfigurationSpec
             FakeFactory(),
             RedisConnectionOwnership.PluginOwned);
 
-        act.Should().Throw<InvalidOperationException>()
+        Assert.Throws<InvalidOperationException>(act)
             .WithMessage("*akka.persistence.journal.redis*");
     }
 

--- a/src/Akka.Persistence.Redis.Tests/Hosting/ConnectionMultiplexerFactorySpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/ConnectionMultiplexerFactorySpec.cs
@@ -13,7 +13,6 @@ using Akka.Persistence;
 using Akka.Persistence.Redis;
 using Akka.Persistence.Redis.Hosting;
 using Akka.Persistence.Redis.Tests;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using StackExchange.Redis;
@@ -47,9 +46,8 @@ public class ConnectionMultiplexerFactorySpec : Akka.Hosting.TestKit.TestKit, IC
     protected override async Task AfterAllAsync()
     {
         // Caller-owned multiplexer: the plugin must NOT have disposed it.
-        _suppliedMultiplexer.Should().NotBeNull();
-        _suppliedMultiplexer!.IsConnected.Should().BeTrue(
-            "the plugin must not dispose caller-owned multiplexers supplied via RedisConnectionMultiplexerSetup");
+        Assert.NotNull(_suppliedMultiplexer);
+        Assert.True(_suppliedMultiplexer!.IsConnected);
 
         _suppliedMultiplexer.Dispose();
 
@@ -76,12 +74,11 @@ public class ConnectionMultiplexerFactorySpec : Akka.Hosting.TestKit.TestKit, IC
     public void Setup_should_be_registered_when_multiplexer_is_supplied()
     {
         var setup = Sys.Settings.Setup.Get<RedisConnectionMultiplexerSetup>();
-        setup.HasValue.Should().BeTrue(
-            "WithRedisPersistence(multiplexer:) must register a RedisConnectionMultiplexerSetup");
-        setup.Value.TryGetSource("akka.persistence.journal.redis", out var journalSource).Should().BeTrue();
-        journalSource!.Ownership.Should().Be(RedisConnectionOwnership.CallerOwned);
-        setup.Value.TryGetSource("akka.persistence.snapshot-store.redis", out var snapshotSource).Should().BeTrue();
-        snapshotSource!.Ownership.Should().Be(RedisConnectionOwnership.CallerOwned);
+        Assert.True(setup.HasValue);
+        Assert.True(setup.Value.TryGetSource("akka.persistence.journal.redis", out var journalSource));
+        Assert.Equal(RedisConnectionOwnership.CallerOwned, journalSource!.Ownership);
+        Assert.True(setup.Value.TryGetSource("akka.persistence.snapshot-store.redis", out var snapshotSource));
+        Assert.Equal(RedisConnectionOwnership.CallerOwned, snapshotSource!.Ownership);
     }
 
     private sealed class FactoryProbeActor : Akka.Persistence.ReceivePersistentActor

--- a/src/Akka.Persistence.Redis.Tests/Hosting/HealthCheckSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/HealthCheckSpec.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Hosting;
 using Akka.Persistence.Redis.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
@@ -63,7 +62,7 @@ public class HealthCheckSpec : Akka.Hosting.TestKit.TestKit, IClassFixture<Redis
         var healthReport = await healthCheckService.CheckHealthAsync(CancellationToken.None);
 
         // Assert - verify that health checks are registered and healthy
-        healthReport.Entries.Should().NotBeEmpty("health checks should be registered");
+        Assert.NotEmpty(healthReport.Entries);
 
         // Debug: print all registered health checks (ALL of them, not just SQL)
         Output?.WriteLine($"Total health checks registered: {healthReport.Entries.Count}");
@@ -78,23 +77,23 @@ public class HealthCheckSpec : Akka.Hosting.TestKit.TestKit, IClassFixture<Redis
             .Where(e => e.Key.Contains("Akka.Persistence", StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        persistenceHealthChecks.Should().HaveCount(2, "because we registered health checks for both journal and snapshot store");
+        Assert.Equal(2, (persistenceHealthChecks)?.Count());
 
         // Verify journal health check exists and is healthy
         var journalHealthCheck = persistenceHealthChecks
             .FirstOrDefault(e => e.Key.Contains("journal", StringComparison.OrdinalIgnoreCase));
 
-        journalHealthCheck.Should().NotBeNull("journal health check should be registered");
-        journalHealthCheck.Value.Status.Should().Be(HealthStatus.Healthy, "SQL journal should be properly initialized");
+        Assert.NotNull(journalHealthCheck);
+        Assert.Equal(HealthStatus.Healthy, journalHealthCheck.Value.Status);
 
         // Verify snapshot health check exists and is healthy
         var snapshotHealthCheck = persistenceHealthChecks
             .FirstOrDefault(e => e.Key.Contains("snapshot", StringComparison.OrdinalIgnoreCase));
 
-        snapshotHealthCheck.Should().NotBeNull("snapshot health check should be registered");
-        snapshotHealthCheck.Value.Status.Should().Be(HealthStatus.Healthy, "SQL snapshot store should be properly initialized");
+        Assert.NotNull(snapshotHealthCheck);
+        Assert.Equal(HealthStatus.Healthy, snapshotHealthCheck.Value.Status);
 
         // Verify overall health status
-        healthReport.Status.Should().Be(HealthStatus.Healthy, "because all health checks should pass");
+        Assert.Equal(HealthStatus.Healthy, healthReport.Status);
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/Hosting/RedisConnectivityCheckSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/RedisConnectivityCheckSpec.cs
@@ -102,7 +102,8 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     {
         // Act & Assert
         var action = () => new RedisJournalConnectivityCheck((string)null!, "redis");
-        Assert.Throws<ArgumentNullException>(action).Where(ex => ex.ParamName == "connectionString");
+        var ex1 = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal("connectionString", ex1.ParamName);
     }
 
     [Fact]
@@ -110,7 +111,8 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     {
         // Act & Assert
         var action = () => new RedisJournalConnectivityCheck("localhost:6379", null!);
-        Assert.Throws<ArgumentNullException>(action).Where(ex => ex.ParamName == "journalId");
+        var ex2 = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal("journalId", ex2.ParamName);
     }
 
     [Fact]
@@ -118,7 +120,8 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     {
         // Act & Assert
         var action = () => new RedisSnapshotStoreConnectivityCheck((string)null!, "redis");
-        Assert.Throws<ArgumentNullException>(action).Where(ex => ex.ParamName == "connectionString");
+        var ex3 = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal("connectionString", ex3.ParamName);
     }
 
     [Fact]
@@ -126,7 +129,8 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     {
         // Act & Assert
         var action = () => new RedisSnapshotStoreConnectivityCheck("localhost:6379", null!);
-        Assert.Throws<ArgumentNullException>(action).Where(ex => ex.ParamName == "snapshotStoreId");
+        var ex4 = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal("snapshotStoreId", ex4.ParamName);
     }
 
     [Fact]

--- a/src/Akka.Persistence.Redis.Tests/Hosting/RedisConnectivityCheckSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/RedisConnectivityCheckSpec.cs
@@ -12,7 +12,6 @@ using Akka.Actor.Setup;
 using Akka.Hosting;
 using Akka.Persistence.Redis;
 using Akka.Persistence.Redis.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using StackExchange.Redis;
 using Xunit;
@@ -46,9 +45,9 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Healthy);
-        result.Exception.Should().BeNull();
-        result.Description.Should().Contain("successful");
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Null(result.Exception);
+        Assert.Contains("successful", result.Description);
     }
 
     [Fact]
@@ -62,9 +61,9 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Healthy);
-        result.Exception.Should().BeNull();
-        result.Description.Should().Contain("successful");
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Null(result.Exception);
+        Assert.Contains("successful", result.Description);
     }
 
     // Unhappy path tests - verify health checks detect connection failures
@@ -79,8 +78,8 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Unhealthy);
-        result.Exception.Should().NotBeNull();
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.NotNull(result.Exception);
     }
 
     [Fact]
@@ -94,8 +93,8 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
         var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
         // Assert
-        result.Status.Should().Be(HealthStatus.Unhealthy);
-        result.Exception.Should().NotBeNull();
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.NotNull(result.Exception);
     }
 
     [Fact]
@@ -103,7 +102,7 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     {
         // Act & Assert
         var action = () => new RedisJournalConnectivityCheck((string)null!, "redis");
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "connectionString");
+        Assert.Throws<ArgumentNullException>(action).Where(ex => ex.ParamName == "connectionString");
     }
 
     [Fact]
@@ -111,7 +110,7 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     {
         // Act & Assert
         var action = () => new RedisJournalConnectivityCheck("localhost:6379", null!);
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "journalId");
+        Assert.Throws<ArgumentNullException>(action).Where(ex => ex.ParamName == "journalId");
     }
 
     [Fact]
@@ -119,7 +118,7 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     {
         // Act & Assert
         var action = () => new RedisSnapshotStoreConnectivityCheck((string)null!, "redis");
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "connectionString");
+        Assert.Throws<ArgumentNullException>(action).Where(ex => ex.ParamName == "connectionString");
     }
 
     [Fact]
@@ -127,7 +126,7 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
     {
         // Act & Assert
         var action = () => new RedisSnapshotStoreConnectivityCheck("localhost:6379", null!);
-        action.Should().Throw<ArgumentNullException>().Where(ex => ex.ParamName == "snapshotStoreId");
+        Assert.Throws<ArgumentNullException>(action).Where(ex => ex.ParamName == "snapshotStoreId");
     }
 
     [Fact]
@@ -148,8 +147,7 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
 
             var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
-            result.Status.Should().Be(HealthStatus.Healthy,
-                "the health check should use the registered journal source instead of the fallback connection string");
+            Assert.Equal(HealthStatus.Healthy, result.Status);
         }
         finally
         {
@@ -175,8 +173,7 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
 
             var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
-            result.Status.Should().Be(HealthStatus.Healthy,
-                "the health check should use the registered snapshot source instead of the fallback connection string");
+            Assert.Equal(HealthStatus.Healthy, result.Status);
         }
         finally
         {
@@ -202,9 +199,8 @@ public class RedisConnectivityCheckSpec : IClassFixture<RedisFixture>
 
             var result = await check.CheckHealthAsync(context, CancellationToken.None);
 
-            result.Status.Should().Be(HealthStatus.Unhealthy,
-                "a setup source for akka.persistence.journal.redis must not be reused for akka.persistence.journal.custom");
-            result.Exception.Should().NotBeNull();
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.NotNull(result.Exception);
         }
         finally
         {

--- a/src/Akka.Persistence.Redis.Tests/Hosting/RedisJournalOptionsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/RedisJournalOptionsSpec.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Text;
 using Akka.Configuration;
 using Akka.Persistence.Redis.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -18,8 +16,8 @@ namespace Akka.Persistence.Redis.Tests.Hosting
             var options = new RedisJournalOptions(true);
             var config = options.ToConfig();
 
-            config.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.redis");
-            config.HasPath("akka.persistence.journal.redis").Should().BeTrue();
+            Assert.Equal("akka.persistence.journal.redis", config.GetString("akka.persistence.journal.plugin"));
+            Assert.True(config.HasPath("akka.persistence.journal.redis"));
         }
 
         [Fact(DisplayName = "Empty RedisJournalOptions should equal empty config with default fallback")]
@@ -30,19 +28,19 @@ namespace Akka.Persistence.Redis.Tests.Hosting
             var baseRootConfig = Config.Empty
                 .WithFallback(RedisPersistence.DefaultConfig());
 
-            emptyRootConfig.GetString("akka.persistence.journal.plugin").Should().Be(baseRootConfig.GetString("akka.persistence.journal.plugin"));
+            Assert.Equal(baseRootConfig.GetString("akka.persistence.journal.plugin"), emptyRootConfig.GetString("akka.persistence.journal.plugin"));
 
             var config = emptyRootConfig.GetConfig("akka.persistence.journal.redis");
             var baseConfig = baseRootConfig.GetConfig("akka.persistence.journal.redis");
-            config.Should().NotBeNull();
-            baseConfig.Should().NotBeNull();
+            Assert.NotNull(config);
+            Assert.NotNull(baseConfig);
 
-            config.GetString("class").Should().Be(baseConfig.GetString("class"));
-            config.GetString("configuration-string").Should().Be(baseConfig.GetString("configuration-string"));
-            config.GetBoolean("auto-initialize").Should().Be(baseConfig.GetBoolean("auto-initialize"));
-            config.GetString("key-prefix").Should().Be(baseConfig.GetString("key-prefix"));
-            config.GetInt("database").Should().Be(baseConfig.GetInt("database"));
-            config.GetBoolean("use-database-number-from-connection-string").Should().Be(baseConfig.GetBoolean("use-database-number-from-connection-string"));
+            Assert.Equal(baseConfig.GetString("class"), config.GetString("class"));
+            Assert.Equal(baseConfig.GetString("configuration-string"), config.GetString("configuration-string"));
+            Assert.Equal(baseConfig.GetBoolean("auto-initialize"), config.GetBoolean("auto-initialize"));
+            Assert.Equal(baseConfig.GetString("key-prefix"), config.GetString("key-prefix"));
+            Assert.Equal(baseConfig.GetInt("database"), config.GetInt("database"));
+            Assert.Equal(baseConfig.GetBoolean("use-database-number-from-connection-string"), config.GetBoolean("use-database-number-from-connection-string"));
         }
 
         [Fact(DisplayName = "Empty RedisJournalOptions with custom identifier should equal empty config with default fallback")]
@@ -53,19 +51,19 @@ namespace Akka.Persistence.Redis.Tests.Hosting
             var baseRootConfig = Config.Empty
                 .WithFallback(RedisPersistence.DefaultConfig());
 
-            emptyRootConfig.GetString("akka.persistence.journal.plugin").Should().Be(baseRootConfig.GetString("akka.persistence.journal.plugin"));
+            Assert.Equal(baseRootConfig.GetString("akka.persistence.journal.plugin"), emptyRootConfig.GetString("akka.persistence.journal.plugin"));
 
             var config = emptyRootConfig.GetConfig("akka.persistence.journal.custom");
             var baseConfig = baseRootConfig.GetConfig("akka.persistence.journal.redis");
-            config.Should().NotBeNull();
-            baseConfig.Should().NotBeNull();
+            Assert.NotNull(config);
+            Assert.NotNull(baseConfig);
 
-            config.GetString("class").Should().Be(baseConfig.GetString("class"));
-            config.GetString("configuration-string").Should().Be(baseConfig.GetString("configuration-string"));
-            config.GetBoolean("auto-initialize").Should().Be(baseConfig.GetBoolean("auto-initialize"));
-            config.GetString("key-prefix").Should().Be(baseConfig.GetString("key-prefix"));
-            config.GetInt("database").Should().Be(baseConfig.GetInt("database"));
-            config.GetBoolean("use-database-number-from-connection-string").Should().Be(baseConfig.GetBoolean("use-database-number-from-connection-string"));
+            Assert.Equal(baseConfig.GetString("class"), config.GetString("class"));
+            Assert.Equal(baseConfig.GetString("configuration-string"), config.GetString("configuration-string"));
+            Assert.Equal(baseConfig.GetBoolean("auto-initialize"), config.GetBoolean("auto-initialize"));
+            Assert.Equal(baseConfig.GetString("key-prefix"), config.GetString("key-prefix"));
+            Assert.Equal(baseConfig.GetInt("database"), config.GetInt("database"));
+            Assert.Equal(baseConfig.GetBoolean("use-database-number-from-connection-string"), config.GetBoolean("use-database-number-from-connection-string"));
         }
 
         [Fact(DisplayName = "RedisJournalOptions should generate proper config")]
@@ -83,15 +81,15 @@ namespace Akka.Persistence.Redis.Tests.Hosting
 
             var baseConfig = options.ToConfig();
 
-            baseConfig.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.custom");
+            Assert.Equal("akka.persistence.journal.custom", baseConfig.GetString("akka.persistence.journal.plugin"));
 
             var config = baseConfig.GetConfig("akka.persistence.journal.custom");
-            config.Should().NotBeNull();
-            config.GetBoolean("auto-initialize").Should().Be(options.AutoInitialize);
-            config.GetString("configuration-string").Should().Be(options.ConfigurationString);
-            config.GetString("key-prefix").Should().Be(options.KeyPrefix);
-            config.GetInt("database").Should().Be(options.Database);
-            config.GetBoolean("use-database-number-from-connection-string").Should().Be(options.UseDatabaseFromConnectionString.Value);
+            Assert.NotNull(config);
+            Assert.Equal(options.AutoInitialize, config.GetBoolean("auto-initialize"));
+            Assert.Equal(options.ConfigurationString, config.GetString("configuration-string"));
+            Assert.Equal(options.KeyPrefix, config.GetString("key-prefix"));
+            Assert.Equal(options.Database, config.GetInt("database"));
+            Assert.Equal(options.UseDatabaseFromConnectionString.Value, config.GetBoolean("use-database-number-from-connection-string"));
         }
 
         const string Json = @"
@@ -123,14 +121,14 @@ namespace Akka.Persistence.Redis.Tests.Hosting
             var jsonConfig = new ConfigurationBuilder().AddJsonStream(stream).Build();
 
             var options = jsonConfig.GetSection("Akka:JournalOptions").Get<RedisJournalOptions>();
-            options.Identifier.Should().Be("customRedis");
-            options.AutoInitialize.Should().BeTrue();
-            options.IsDefaultPlugin.Should().BeFalse();
-            options.ConfigurationString.Should().Be("ConfigurationStringFromConfigJson");
-            options.KeyPrefix.Should().Be("KeyPrefixFromConfigJson");
-            options.Database.Should().Be(123456);
-            options.UseDatabaseFromConnectionString.Should().BeTrue();
-            options.Serializer.Should().Be("TestSerializer");
+            Assert.Equal("customRedis", options.Identifier);
+            Assert.True(options.AutoInitialize);
+            Assert.False(options.IsDefaultPlugin);
+            Assert.Equal("ConfigurationStringFromConfigJson", options.ConfigurationString);
+            Assert.Equal("KeyPrefixFromConfigJson", options.KeyPrefix);
+            Assert.Equal(123456, options.Database);
+            Assert.True(options.UseDatabaseFromConnectionString);
+            Assert.Equal("TestSerializer", options.Serializer);
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/Hosting/RedisSnapshotOptionsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/RedisSnapshotOptionsSpec.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Text;
 using Akka.Configuration;
 using Akka.Persistence.Redis.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -18,8 +16,8 @@ namespace Akka.Persistence.Redis.Tests.Hosting
             var options = new RedisSnapshotOptions(true);
             var config = options.ToConfig();
 
-            config.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.redis");
-            config.HasPath("akka.persistence.snapshot-store.redis").Should().BeTrue();
+            Assert.Equal("akka.persistence.snapshot-store.redis", config.GetString("akka.persistence.snapshot-store.plugin"));
+            Assert.True(config.HasPath("akka.persistence.snapshot-store.redis"));
         }
 
         [Fact(DisplayName = "Empty RedisSnapshotOptions should equal empty config with default fallback")]
@@ -30,19 +28,19 @@ namespace Akka.Persistence.Redis.Tests.Hosting
             var baseRootConfig = Config.Empty
                 .WithFallback(RedisPersistence.DefaultConfig());
 
-            emptyRootConfig.GetString("akka.persistence.snapshot-store.plugin").Should().Be(baseRootConfig.GetString("akka.persistence.snapshot-store.plugin"));
+            Assert.Equal(baseRootConfig.GetString("akka.persistence.snapshot-store.plugin"), emptyRootConfig.GetString("akka.persistence.snapshot-store.plugin"));
 
             var config = emptyRootConfig.GetConfig("akka.persistence.snapshot-store.redis");
             var baseConfig = baseRootConfig.GetConfig("akka.persistence.snapshot-store.redis");
-            config.Should().NotBeNull();
-            baseConfig.Should().NotBeNull();
+            Assert.NotNull(config);
+            Assert.NotNull(baseConfig);
 
-            config.GetString("class").Should().Be(baseConfig.GetString("class"));
-            config.GetString("configuration-string").Should().Be(baseConfig.GetString("configuration-string"));
-            config.GetBoolean("auto-initialize").Should().Be(baseConfig.GetBoolean("auto-initialize"));
-            config.GetString("key-prefix").Should().Be(baseConfig.GetString("key-prefix"));
-            config.GetInt("database").Should().Be(baseConfig.GetInt("database"));
-            config.GetBoolean("use-database-number-from-connection-string").Should().Be(baseConfig.GetBoolean("use-database-number-from-connection-string"));
+            Assert.Equal(baseConfig.GetString("class"), config.GetString("class"));
+            Assert.Equal(baseConfig.GetString("configuration-string"), config.GetString("configuration-string"));
+            Assert.Equal(baseConfig.GetBoolean("auto-initialize"), config.GetBoolean("auto-initialize"));
+            Assert.Equal(baseConfig.GetString("key-prefix"), config.GetString("key-prefix"));
+            Assert.Equal(baseConfig.GetInt("database"), config.GetInt("database"));
+            Assert.Equal(baseConfig.GetBoolean("use-database-number-from-connection-string"), config.GetBoolean("use-database-number-from-connection-string"));
         }
 
         [Fact(DisplayName = "Empty RedisSnapshotOptions with custom identifier should equal empty config with default fallback")]
@@ -53,19 +51,19 @@ namespace Akka.Persistence.Redis.Tests.Hosting
             var baseRootConfig = Config.Empty
                 .WithFallback(RedisPersistence.DefaultConfig());
 
-            emptyRootConfig.GetString("akka.persistence.snapshot-store.plugin").Should().Be(baseRootConfig.GetString("akka.persistence.snapshot-store.plugin"));
+            Assert.Equal(baseRootConfig.GetString("akka.persistence.snapshot-store.plugin"), emptyRootConfig.GetString("akka.persistence.snapshot-store.plugin"));
 
             var config = emptyRootConfig.GetConfig("akka.persistence.snapshot-store.custom");
             var baseConfig = baseRootConfig.GetConfig("akka.persistence.snapshot-store.redis");
-            config.Should().NotBeNull();
-            baseConfig.Should().NotBeNull();
+            Assert.NotNull(config);
+            Assert.NotNull(baseConfig);
 
-            config.GetString("class").Should().Be(baseConfig.GetString("class"));
-            config.GetString("configuration-string").Should().Be(baseConfig.GetString("configuration-string"));
-            config.GetBoolean("auto-initialize").Should().Be(baseConfig.GetBoolean("auto-initialize"));
-            config.GetString("key-prefix").Should().Be(baseConfig.GetString("key-prefix"));
-            config.GetInt("database").Should().Be(baseConfig.GetInt("database"));
-            config.GetBoolean("use-database-number-from-connection-string").Should().Be(baseConfig.GetBoolean("use-database-number-from-connection-string"));
+            Assert.Equal(baseConfig.GetString("class"), config.GetString("class"));
+            Assert.Equal(baseConfig.GetString("configuration-string"), config.GetString("configuration-string"));
+            Assert.Equal(baseConfig.GetBoolean("auto-initialize"), config.GetBoolean("auto-initialize"));
+            Assert.Equal(baseConfig.GetString("key-prefix"), config.GetString("key-prefix"));
+            Assert.Equal(baseConfig.GetInt("database"), config.GetInt("database"));
+            Assert.Equal(baseConfig.GetBoolean("use-database-number-from-connection-string"), config.GetBoolean("use-database-number-from-connection-string"));
         }
 
         [Fact(DisplayName = "RedisSnapshotOptions should generate proper config")]
@@ -83,15 +81,15 @@ namespace Akka.Persistence.Redis.Tests.Hosting
 
             var baseConfig = options.ToConfig();
 
-            baseConfig.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.custom");
+            Assert.Equal("akka.persistence.snapshot-store.custom", baseConfig.GetString("akka.persistence.snapshot-store.plugin"));
 
             var config = baseConfig.GetConfig("akka.persistence.snapshot-store.custom");
-            config.Should().NotBeNull();
-            config.GetBoolean("auto-initialize").Should().Be(options.AutoInitialize);
-            config.GetString("configuration-string").Should().Be(options.ConfigurationString);
-            config.GetString("key-prefix").Should().Be(options.KeyPrefix);
-            config.GetInt("database").Should().Be(options.Database);
-            config.GetBoolean("use-database-number-from-connection-string").Should().Be(options.UseDatabaseFromConnectionString.Value);
+            Assert.NotNull(config);
+            Assert.Equal(options.AutoInitialize, config.GetBoolean("auto-initialize"));
+            Assert.Equal(options.ConfigurationString, config.GetString("configuration-string"));
+            Assert.Equal(options.KeyPrefix, config.GetString("key-prefix"));
+            Assert.Equal(options.Database, config.GetInt("database"));
+            Assert.Equal(options.UseDatabaseFromConnectionString.Value, config.GetBoolean("use-database-number-from-connection-string"));
         }
 
         const string Json = @"
@@ -123,14 +121,14 @@ namespace Akka.Persistence.Redis.Tests.Hosting
             var jsonConfig = new ConfigurationBuilder().AddJsonStream(stream).Build();
 
             var options = jsonConfig.GetSection("Akka:SnapshotOptions").Get<RedisSnapshotOptions>();
-            options.Identifier.Should().Be("customRedis");
-            options.AutoInitialize.Should().BeTrue();
-            options.IsDefaultPlugin.Should().BeFalse();
-            options.ConfigurationString.Should().Be("ConfigurationStringFromConfigJson");
-            options.KeyPrefix.Should().Be("KeyPrefixFromConfigJson");
-            options.Database.Should().Be(123456);
-            options.UseDatabaseFromConnectionString.Should().BeTrue();
-            options.Serializer.Should().Be("TestSerializer");
+            Assert.Equal("customRedis", options.Identifier);
+            Assert.True(options.AutoInitialize);
+            Assert.False(options.IsDefaultPlugin);
+            Assert.Equal("ConfigurationStringFromConfigJson", options.ConfigurationString);
+            Assert.Equal("KeyPrefixFromConfigJson", options.KeyPrefix);
+            Assert.Equal(123456, options.Database);
+            Assert.True(options.UseDatabaseFromConnectionString);
+            Assert.Equal("TestSerializer", options.Serializer);
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/Hosting/SimplifiedConnectivityCheckApiSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/SimplifiedConnectivityCheckApiSpec.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Hosting;
 using Akka.Persistence.Redis.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
@@ -65,7 +64,7 @@ public class SimplifiedConnectivityCheckApiSpec : Akka.Hosting.TestKit.TestKit, 
         var healthReport = await healthCheckService.CheckHealthAsync(CancellationToken.None);
 
         // Assert
-        healthReport.Entries.Should().NotBeEmpty("health checks should be registered");
+        Assert.NotEmpty(healthReport.Entries);
 
         // Look for connectivity checks
         var journalConnectivityCheck = healthReport.Entries
@@ -76,8 +75,8 @@ public class SimplifiedConnectivityCheckApiSpec : Akka.Hosting.TestKit.TestKit, 
             .FirstOrDefault(e => e.Key.Contains("Redis.SnapshotStore", StringComparison.OrdinalIgnoreCase) &&
                                 e.Key.Contains("Connectivity", StringComparison.OrdinalIgnoreCase));
 
-        journalConnectivityCheck.Key.Should().NotBeNull("journal connectivity check should be registered");
-        snapshotConnectivityCheck.Key.Should().NotBeNull("snapshot connectivity check should be registered");
+        Assert.NotNull(journalConnectivityCheck.Key);
+        Assert.NotNull(snapshotConnectivityCheck.Key);
     }
 }
 
@@ -127,12 +126,12 @@ public class CustomConnectivityCheckConfigSpec : Akka.Hosting.TestKit.TestKit, I
         var healthReport = await healthCheckService.CheckHealthAsync(CancellationToken.None);
 
         // Assert
-        healthReport.Entries.Should().NotBeEmpty("health checks should be registered");
+        Assert.NotEmpty(healthReport.Entries);
 
         // Look for the custom named check
         var customCheck = healthReport.Entries
             .FirstOrDefault(e => e.Key == "MyCustomRedisJournalCheck");
 
-        customCheck.Key.Should().NotBeNull("custom named health check should be registered");
+        Assert.NotNull(customCheck.Key);
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/Hosting/SnapshotOnlyHostingSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/Hosting/SnapshotOnlyHostingSpec.cs
@@ -8,7 +8,6 @@ using System;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
 using Akka.Persistence.Redis.Hosting;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Persistence.Redis.Tests.Hosting;
@@ -43,18 +42,14 @@ public class SnapshotOnlyHostingSpec : Akka.Hosting.TestKit.TestKit, IClassFixtu
     {
         var snapshotStoreConfig = Sys.Settings.Config.GetConfig("akka.persistence.snapshot-store.redis");
 
-        snapshotStoreConfig.Should().NotBeNull(
-            "the snapshot-only branch must call AddHocon(RedisPersistence.DefaultConfig(), HoconAddMode.Append)");
+        Assert.NotNull(snapshotStoreConfig);
 
-        snapshotStoreConfig.GetString("class")
-            .Should().Contain("RedisSnapshotStore",
-                "the redis snapshot-store HOCON section must include the plugin class name");
+        Assert.Contains("RedisSnapshotStore", snapshotStoreConfig.GetString("class"));
     }
 
     [Fact]
     public void Snapshot_only_configuration_should_set_snapshot_store_plugin_to_redis()
     {
-        Sys.Settings.Config.GetString("akka.persistence.snapshot-store.plugin")
-            .Should().Be("akka.persistence.snapshot-store.redis");
+        Assert.Equal("akka.persistence.snapshot-store.redis", Sys.Settings.Config.GetString("akka.persistence.snapshot-store.plugin"));
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalLifecycleSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalLifecycleSpec.cs
@@ -67,8 +67,8 @@ namespace Akka.Persistence.Redis.Tests
                 () =>
                 {
                     var afterShutdown = TotalClientCountAsync(observer).GetAwaiter().GetResult();
-                    afterShutdown.Should().BeLessThanOrEqualTo(baseline,
-                        because: "the owned multiplexer should be disposed on PostStop, releasing every connection it opened");
+                    Assert.True(afterShutdown <= baseline,
+                        "the owned multiplexer should be disposed on PostStop, releasing every connection it opened");
                 },
                 TimeSpan.FromSeconds(10));
         }

--- a/src/Akka.Persistence.Redis.Tests/RedisJournalLifecycleSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisJournalLifecycleSpec.cs
@@ -11,7 +11,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Akka.TestKit.Xunit;
-using FluentAssertions;
 using StackExchange.Redis;
 using Xunit;
 
@@ -55,8 +54,7 @@ namespace Akka.Persistence.Redis.Tests
                 probe.ExpectMsg<RecoverySuccess>(TimeSpan.FromSeconds(10));
 
                 var withJournal = await TotalClientCountAsync(observer);
-                withJournal.Should().BeGreaterThan(baseline,
-                    because: "the journal's ConnectionMultiplexer should hold at least one client connection while the actor is alive");
+                Assert.True((withJournal) > (baseline));
             }
             finally
             {

--- a/src/Akka.Persistence.Redis.Tests/RedisMultiConfigurationSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisMultiConfigurationSpec.cs
@@ -9,7 +9,6 @@ using Akka.Cluster.Sharding;
 using Akka.Configuration;
 using Akka.Persistence.Redis.Journal;
 using Akka.Persistence.TCK;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Persistence.Redis.Tests
@@ -63,22 +62,22 @@ akka.persistence {
         public void PluginMustBeAbleToUseDifferentConfigurationForPersistence()
         {
             var cluster = ClusterSharding.Get(Sys);
-            cluster.Settings.JournalPluginId.Should().Be("akka.persistence.journal.sharding");
-            cluster.Settings.SnapshotPluginId.Should().Be("akka.persistence.snapshot-store.sharding");
+            Assert.Equal("akka.persistence.journal.sharding", cluster.Settings.JournalPluginId);
+            Assert.Equal("akka.persistence.snapshot-store.sharding", cluster.Settings.SnapshotPluginId);
 
             var persistence = Persistence.Instance.Get(Sys);
             
             var @ref = persistence.JournalFor("akka.persistence.journal.redis");
-            @ref.Should().NotBeNull();
+            Assert.NotNull(@ref);
 
             @ref = persistence.SnapshotStoreFor("akka.persistence.snapshot-store.redis");
-            @ref.Should().NotBeNull();
+            Assert.NotNull(@ref);
             
             @ref = persistence.JournalFor("akka.persistence.journal.sharding");
-            @ref.Should().NotBeNull();
+            Assert.NotNull(@ref);
 
             @ref = persistence.SnapshotStoreFor("akka.persistence.snapshot-store.sharding");
-            @ref.Should().NotBeNull();
+            Assert.NotNull(@ref);
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/RedisSettingsSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisSettingsSpec.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="RedisSettingsSpec.cs" company="Akka.NET Project">
-//      Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// </copyright>
-// -----------------------------------------------------------------------
-
-using FluentAssertions;
-using Xunit;
+﻿using Xunit;
 
 namespace Akka.Persistence.Redis.Tests
 {
@@ -17,9 +10,9 @@ namespace Akka.Persistence.Redis.Tests
             var redisPersistence = RedisPersistence.Get(Sys);
             var settings = RedisSettings.Create(redisPersistence.DefaultJournalConfig);
 
-            settings.ConfigurationString.Should().Be(string.Empty);
-            settings.Database.Should().Be(0);
-            settings.KeyPrefix.Should().Be(string.Empty);
+            Assert.Equal(string.Empty, settings.ConfigurationString);
+            Assert.Equal(0, settings.Database);
+            Assert.Equal(string.Empty, settings.KeyPrefix);
         }
 
         [Fact]
@@ -28,9 +21,9 @@ namespace Akka.Persistence.Redis.Tests
             var redisPersistence = RedisPersistence.Get(Sys);
             var settings = RedisSettings.Create(redisPersistence.DefaultSnapshotConfig);
 
-            settings.ConfigurationString.Should().Be(string.Empty);
-            settings.Database.Should().Be(0);
-            settings.KeyPrefix.Should().Be(string.Empty);
+            Assert.Equal(string.Empty, settings.ConfigurationString);
+            Assert.Equal(0, settings.Database);
+            Assert.Equal(string.Empty, settings.KeyPrefix);
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/RedisSnapshotStoreLifecycleSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisSnapshotStoreLifecycleSpec.cs
@@ -67,8 +67,8 @@ namespace Akka.Persistence.Redis.Tests
                 () =>
                 {
                     var afterShutdown = TotalClientCountAsync(observer).GetAwaiter().GetResult();
-                    afterShutdown.Should().BeLessThanOrEqualTo(baseline,
-                        because: "the owned multiplexer should be disposed on PostStop, releasing every connection it opened");
+                    Assert.True(afterShutdown <= baseline,
+                        "the owned multiplexer should be disposed on PostStop, releasing every connection it opened");
                 },
                 TimeSpan.FromSeconds(10));
         }

--- a/src/Akka.Persistence.Redis.Tests/RedisSnapshotStoreLifecycleSpec.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisSnapshotStoreLifecycleSpec.cs
@@ -11,7 +11,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Akka.TestKit.Xunit;
-using FluentAssertions;
 using StackExchange.Redis;
 using Xunit;
 
@@ -57,8 +56,7 @@ namespace Akka.Persistence.Redis.Tests
                 probe.ExpectMsg<LoadSnapshotResult>(TimeSpan.FromSeconds(10));
 
                 var withSnapshotStore = await TotalClientCountAsync(observer);
-                withSnapshotStore.Should().BeGreaterThan(baseline,
-                    because: "the snapshot store's ConnectionMultiplexer should hold at least one client connection while the actor is alive");
+                Assert.True((withSnapshotStore) > (baseline));
             }
             finally
             {

--- a/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
@@ -169,7 +169,7 @@ namespace Akka.Persistence.Redis.Tests
             Action act = () => refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
             Assert.Null(Record.Exception(act));
 
-            await AwaitAssertAsync(() => invocations.Should().BeGreaterOrEqualTo(1), TimeSpan.FromSeconds(2));
+            await AwaitAssertAsync(() => Assert.True(invocations >= 1), TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
+++ b/src/Akka.Persistence.Redis.Tests/RedisTopologyRefresherSpecs.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using StackExchange.Redis;
 using Xunit;
 
@@ -26,7 +25,7 @@ namespace Akka.Persistence.Redis.Tests
             var ex = new RedisCommandException(
                 "Command cannot be issued to a replica: SET {_EventId-1}.Catalog.MarketSnapshot");
 
-            NewRefresher().IsReplicaRefusal(ex).Should().BeTrue();
+            Assert.True(NewRefresher().IsReplicaRefusal(ex));
         }
 
         [Fact]
@@ -36,7 +35,7 @@ namespace Akka.Persistence.Redis.Tests
             // react to it (would cause double-refresh storms).
             var ex = new RedisCommandException("MOVED 1234 192.168.0.5:6379");
 
-            NewRefresher().IsReplicaRefusal(ex).Should().BeFalse();
+            Assert.False(NewRefresher().IsReplicaRefusal(ex));
         }
 
         [Fact]
@@ -44,7 +43,7 @@ namespace Akka.Persistence.Redis.Tests
         {
             var ex = new RedisCommandException("WRONGTYPE Operation against a key holding the wrong kind of value");
 
-            NewRefresher().IsReplicaRefusal(ex).Should().BeFalse();
+            Assert.False(NewRefresher().IsReplicaRefusal(ex));
         }
 
         [Fact]
@@ -65,7 +64,7 @@ namespace Akka.Persistence.Redis.Tests
                 "WriteBatch",
                 new RedisCommandException("Command cannot be issued to a replica: SET foo"));
 
-            invocations.Should().Be(1);
+            Assert.Equal(1, invocations);
 
             gate.SetResult(0);
         }
@@ -91,7 +90,7 @@ namespace Akka.Persistence.Redis.Tests
             refresher.TriggerBackgroundRefresh("pid-2", "WriteBatch", ex);
             refresher.TriggerBackgroundRefresh("pid-3", "WriteBatch", ex);
 
-            invocations.Should().Be(1);
+            Assert.Equal(1, invocations);
 
             gate.SetResult(0);
         }
@@ -118,14 +117,14 @@ namespace Akka.Persistence.Redis.Tests
             var ex = new RedisCommandException("Command cannot be issued to a replica");
 
             refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
-            invocations.Should().Be(1);
+            Assert.Equal(1, invocations);
             gate.SetResult(0);
 
             gate = new TaskCompletionSource<int>();
             await AwaitAssertAsync(() =>
             {
                 refresher.TriggerBackgroundRefresh("pid-2", "WriteBatch", ex);
-                invocations.Should().Be(2);
+                Assert.Equal(2, invocations);
             }, TimeSpan.FromSeconds(2));
 
             gate.SetResult(0);
@@ -168,7 +167,7 @@ namespace Akka.Persistence.Redis.Tests
             var ex = new RedisCommandException("Command cannot be issued to a replica");
 
             Action act = () => refresher.TriggerBackgroundRefresh("pid-1", "WriteBatch", ex);
-            act.Should().NotThrow();
+            Assert.Null(Record.Exception(act));
 
             await AwaitAssertAsync(() => invocations.Should().BeGreaterOrEqualTo(1), TimeSpan.FromSeconds(2));
         }


### PR DESCRIPTION
Migrated all FluentAssertions .Should() calls to xUnit v3 Assert.* equivalents. Removed FluentAssertions package references from all projects.