### PR TITLE
Upgrade Akka.Persistence.Redis to Akka.NET 1.5.70

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,6 +36,6 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReleaseNotes>* Upgraded to Akka.NET 1.5.70.
 * Upgraded to Akka.Hosting 1.5.70.
-* Event queries by persistence ID remain supported. Persistence-ID enumeration, tag, and all-events queries, including `Offset.FromEnd`, remain unavailable because Redis Cluster does not provide the required global ordering.</PackageReleaseNotes>
+* Event queries by persistence ID remain supported. Persistence-ID enumeration remains unimplemented. Tag and all-events queries, including `Offset.FromEnd`, remain unavailable because the clustered storage model does not maintain the required global indexes and ordering.</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2023 Akka.NET Project</Copyright>
     <Authors>Akka.NET</Authors>
-    <VersionPrefix>1.5.68</VersionPrefix>
+    <VersionPrefix>1.5.70</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Akka.NET Persistence journal and snapshot store backed by Redis.</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -34,33 +34,8 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.Redis</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageReleaseNotes>This is the stable release of the post-1.5.67 Redis hardening work.
-
-**Behavior Changes / Compatibility Notes**
-
-* Removed the legacy query subscriber notification protocol (`ISubscriptionCommand`, `SubscribeNewEvents`, and `NewEventAppended`). Live persistence queries now rely exclusively on polling via `akka.persistence.query.journal.redis.refresh-interval`. This removes a dead actor-local optimization that could leak subscribers and race with journal writes. Users that need lower live-query latency can reduce the Redis query `refresh-interval`.
-* Redis journal and snapshot-store connections are now created during plugin actor construction instead of lazily on first database access. This fixes a `ConnectionMultiplexer` lifecycle leak and allows plugin-owned connections to be disposed when the actor stops, but connection failures may now surface earlier during plugin startup.
-* Akka.Hosting Redis configuration now validates missing connection sources earlier. Each configured Redis journal or snapshot store must have either a HOCON connection string or a matching `RedisConnectionMultiplexerSetup` entry.
-
-**Improvements**
-
-* Added `WithAzureRedisPersistence(...)` for Azure Managed Redis and Azure Cache for Redis using Entra ID / Managed Identity authentication. The helper configures TLS, RESP3, `SslHost`, and token authentication via `Microsoft.Azure.StackExchangeRedis`.
-* Added plugin-scoped `RedisConnectionMultiplexerSetup` support for caller-supplied multiplexers and multiplexer factories. Setup entries are keyed by Redis plugin id, so one Redis plugin's injected connection source does not override another plugin's HOCON connection string.
-* Added explicit Redis connection ownership semantics via `RedisConnectionOwnership`: caller-owned, plugin-owned, and actor-system-owned.
-* Updated Redis health checks so setup-backed plugins reuse the configured connection source, while HOCON-only plugins open a temporary multiplexer for the probe and dispose it after `PING`.
-* Fixed snapshot-only Akka.Hosting configuration so Redis default HOCON is still loaded when only the snapshot store is configured.
-* Fixed `DeferAsync` with an empty write batch, which previously could throw from `ContinueWhenAll`.
-* Added `CommandFlags.DemandMaster` to Redis write operations as defense-in-depth for primary-only writes.
-* Removed the `ConnectionMultiplexer` leak in journal and snapshot actors by tracking connection ownership and disposing plugin-owned connections from `PostStop`.
-* Reworked Redis test fixtures to use Testcontainers and hardened cluster readiness / CI failure behavior.
-* Added automatic Redis Cluster topology refresh on the "Command cannot be issued to a replica" error that surfaces after a failover demotes a primary. The journal and snapshot store catch this case, fire `IConnectionMultiplexer.ConfigureAsync()` in the background, and rethrow so the existing circuit breaker handles retry timing. Detection uses `IServer.IsReplica` against the endpoint in `Exception.Data["redis-server"]`, with the literal message as a fallback when `ConfigurationOptions.IncludeDetailInExceptions = false`.
-* Added a new "Running against Redis Cluster" section to `README.md` covering the recommended SE.Redis connection string, Akka.Persistence circuit-breaker tuning, the `Ask` timeout vs `call-timeout` rule, and which cluster-failover failure modes are handled by StackExchange.Redis vs the plugin.
-* Added commented circuit-breaker tuning guidance under the journal and snapshot-store sections of `reference.conf`. No HOCON defaults change.
-
-**Dependencies**
-
-* Upgraded `StackExchange.Redis` to 2.12.14.
-* Added `Microsoft.Azure.StackExchangeRedis` 3.3.1 and `Azure.Identity` 1.17.1 to `Akka.Persistence.Redis.Hosting`.
-* Updated test/build dependencies including `Microsoft.NET.Test.Sdk`, `coverlet.collector`, `Testcontainers`, and `Microsoft.SourceLink.GitHub`.</PackageReleaseNotes>
+    <PackageReleaseNotes>* Upgraded to Akka.NET 1.5.70.
+* Upgraded to Akka.Hosting 1.5.70.
+* Event queries by persistence ID remain supported. Persistence-ID enumeration, tag, and all-events queries, including `Offset.FromEnd`, remain unavailable because Redis Cluster does not provide the required global ordering.</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.68</AkkaVersion>
-    <AkkaHostingVersion>1.5.68</AkkaHostingVersion>
+    <AkkaVersion>1.5.70</AkkaVersion>
+    <AkkaHostingVersion>1.5.70</AkkaHostingVersion>
   </PropertyGroup>
   <!-- Library dependencies -->
   <ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.70 July 29th 2026 ####
+
+* Upgraded to [Akka.NET 1.5.70](https://github.com/akkadotnet/akka.net/releases/tag/1.5.70)
+* Upgraded to [Akka.Hosting 1.5.70](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.70)
+* Event queries by persistence ID remain supported. Persistence-ID enumeration, tag, and all-events queries, including `Offset.FromEnd`, remain unavailable because Redis Cluster does not provide the required global ordering.
+
 #### 1.5.68 June 1st 2026 ####
 
 This is the stable release of the post-1.5.67 Redis hardening work.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 * Upgraded to [Akka.NET 1.5.70](https://github.com/akkadotnet/akka.net/releases/tag/1.5.70)
 * Upgraded to [Akka.Hosting 1.5.70](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.70)
-* Event queries by persistence ID remain supported. Persistence-ID enumeration, tag, and all-events queries, including `Offset.FromEnd`, remain unavailable because Redis Cluster does not provide the required global ordering.
+* Event queries by persistence ID remain supported. Persistence-ID enumeration remains unimplemented. Tag and all-events queries, including `Offset.FromEnd`, remain unavailable because the clustered storage model does not maintain the required global indexes and ordering.
 
 #### 1.5.68 June 1st 2026 ####
 


### PR DESCRIPTION
## Summary

- upgrade Akka.NET and Akka.Hosting dependencies and package version to 1.5.70
- document the supported query boundary for Offset.FromEnd
- retain event queries by persistence ID
- document persistence-ID enumeration as unimplemented
- keep tag and all-events queries unavailable because the clustered storage model does not maintain the required global indexes and ordering

Persistence-ID queries use sequence-number bounds rather than Offset, so there is no compatible Offset.FromEnd surface to add without introducing a different query contract.

## Validation

- Release solution build and package
- non-cluster test suite: 149 passed, 1 existing skip
- cluster event-by-persistence-ID TCK: 17 passed
- audited package dependencies and release notes: stable Akka.NET/Akka.Hosting 1.5.70